### PR TITLE
Fix wmbusmetersd symlink

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,7 @@ rm -f "$ROOT"/usr/bin/wmbusmeters "$ROOT"/usr/sbin/wmbusmetersd
 mkdir -p "$ROOT"/usr/bin
 mkdir -p "$ROOT"/usr/sbin
 cp "$SRC" "$ROOT"/usr/bin/wmbusmeters
-ln -s "$ROOT"/usr/bin/wmbusmeters "$ROOT"/usr/sbin/wmbusmetersd
+ln -s /usr/bin/wmbusmeters "$ROOT"/usr/sbin/wmbusmetersd
 
 echo binaries: installed "$ROOT"/usr/bin/wmbusmeters and "$ROOT"/usr/sbin/wmbusmetersd
 


### PR DESCRIPTION
When building the package, install script creates incorrect symlink
pointing to the build directory instead of target root.