### PR TITLE
Fix compilation error on gcc 10.x

### DIFF
--- a/src/units.h
+++ b/src/units.h
@@ -33,19 +33,19 @@
     X(Time,Hour)           \
 
 #define LIST_OF_UNITS \
-    X(KWH,kwh,kWh,Energy,"kilo Watt hour")  \
-    X(GJ,gj,GJ,Energy,"Giga Joule")         \
-    X(M3,m3,m3,Volume,"cubic meter")        \
-    X(L,l,l,Volume,"litre")                 \
-    X(KW,kw,kW,Power,"kilo Watt")           \
-    X(M3H,m3h,m3/h,Flow,"cubic meters per hour") \
-    X(C,c,°C,Temperature,"celsius")         \
-    X(F,f,°F,Temperature,"fahrenheit")      \
-    X(RH,rh,RH,RelativeHumidity,"relative humidity")      \
-    X(HCA,hca,hca,HCA,"heat cost allocation") \
-    X(TXT,txt,txt,Text,"text")              \
-    X(Second,s,s,Time,"second")           \
-    X(Hour,h,h,Time,"hour")
+    X(KWH,kwh,"kWh",Energy,"kilo Watt hour")  \
+    X(GJ,gj,"GJ",Energy,"Giga Joule")         \
+    X(M3,m3,"m3",Volume,"cubic meter")        \
+    X(L,l,"l",Volume,"litre")                 \
+    X(KW,kw,"kW",Power,"kilo Watt")           \
+    X(M3H,m3h,"m3/h",Flow,"cubic meters per hour") \
+    X(C,c,"°C",Temperature,"celsius")         \
+    X(F,f,"°F",Temperature,"fahrenheit")      \
+    X(RH,rh,"RH",RelativeHumidity,"relative humidity")      \
+    X(HCA,hca,"hca",HCA,"heat cost allocation") \
+    X(TXT,txt,"txt",Text,"text")              \
+    X(Second,s,"s",Time,"second")           \
+    X(Hour,h,"h",Time,"hour")
 
 enum class Unit
 {


### PR DESCRIPTION
Fixes the following compilation error:

 In file included from src/config.h:21,
                  from src/cmdline.h:21,
                  from src/cmdline.cc:18:
 src/units.h:42:11: error: extended character Â° is not valid in an identifier
    42 |     X(C,c,Â°C,Temperature,"celsius")         \
       |           ^
 src/units.h:43:11: error: extended character Â° is not valid in an identifier
    43 |     X(F,f,Â°F,Temperature,"fahrenheit")      \
       |           ^
 make: *** [Makefile:93: build/cmdline.o] Error 1

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>