### PR TITLE
amb8465: Fix RSSI in responses

### DIFF
--- a/src/wmbus_amb8465.cc
+++ b/src/wmbus_amb8465.cc
@@ -222,9 +222,7 @@ void WMBusAmber::getConfiguration()
         verbose("(amb8465) config: radio Channel %02x\n", received_payload_[60+2]);
         uchar re = received_payload_[69+2];
         verbose("(amb8465) config: rssi enabled %02x\n", re);
-        if (re != 0) {
-            rssi_expected_ = true;
-        }
+        rssi_expected_ = (re != 0) ? true : false;
         verbose("(amb8465) config: mode Preselect %02x\n", received_payload_[70+2]);
     }
 

--- a/src/wmbus_amb8465.cc
+++ b/src/wmbus_amb8465.cc
@@ -326,6 +326,7 @@ FrameStatus WMBusAmber::checkAMB8465Frame(vector<uchar> &data,
 
         if (rssi_len) {
             *rssi = data[*frame_length-2];
+            verbose("(amb8465) rssi %d\n", *rssi);
         }
         debug("(amb8465) received full command frame\n");
         return FullFrame;
@@ -345,6 +346,13 @@ FrameStatus WMBusAmber::checkAMB8465Frame(vector<uchar> &data,
     }
 
     debug("(amb8465) received full frame\n");
+
+    if (rssi_expected_)
+    {
+        *rssi = data[*frame_length-1];
+        verbose("(amb8465) rssi %d\n", *rssi);
+    }
+
     return FullFrame;
 }
 
@@ -390,10 +398,6 @@ void WMBusAmber::processSerialData()
 
             read_buffer_.erase(read_buffer_.begin(), read_buffer_.begin()+frame_length);
 
-            if (rssi_expected_)
-            {
-                verbose("(amb8465) rssi %d\n", rssi);
-            }
             handleMessage(msgid, payload);
         }
     }

--- a/src/wmbus_amb8465.cc
+++ b/src/wmbus_amb8465.cc
@@ -324,12 +324,13 @@ FrameStatus WMBusAmber::checkAMB8465Frame(vector<uchar> &data,
             return PartialFrame;
         }
 
+        debug("(amb8465) received full command frame\n");
+
         if (rssi_len) {
             *rssi = data[*frame_length-2];
             signed int dbm = (*rssi >= 128) ? (*rssi - 256) / 2 - 74 : *rssi / 2 - 74;
             verbose("(amb8465) rssi %d (%d dBm)\n", *rssi, dbm);
         }
-        debug("(amb8465) received full command frame\n");
         return FullFrame;
     }
     // If it is not a 0xff we assume it is a message beginning with a length.

--- a/src/wmbus_amb8465.cc
+++ b/src/wmbus_amb8465.cc
@@ -218,6 +218,7 @@ void WMBusAmber::getConfiguration()
         //
         // These are just some random config settings store in non-volatile memory.
         verbose("(amb8465) config: uart %02x\n", received_payload_[2]);
+        verbose("(amb8465) config: IND output enabled %02x\n", received_payload_[5+2]);
         verbose("(amb8465) config: radio Channel %02x\n", received_payload_[60+2]);
         uchar re = received_payload_[69+2];
         verbose("(amb8465) config: rssi enabled %02x\n", re);

--- a/src/wmbus_amb8465.cc
+++ b/src/wmbus_amb8465.cc
@@ -326,7 +326,8 @@ FrameStatus WMBusAmber::checkAMB8465Frame(vector<uchar> &data,
 
         if (rssi_len) {
             *rssi = data[*frame_length-2];
-            verbose("(amb8465) rssi %d\n", *rssi);
+            signed int dbm = (*rssi >= 128) ? (*rssi - 256) / 2 - 74 : *rssi / 2 - 74;
+            verbose("(amb8465) rssi %d (%d dBm)\n", *rssi, dbm);
         }
         debug("(amb8465) received full command frame\n");
         return FullFrame;
@@ -350,7 +351,8 @@ FrameStatus WMBusAmber::checkAMB8465Frame(vector<uchar> &data,
     if (rssi_expected_)
     {
         *rssi = data[*frame_length-1];
-        verbose("(amb8465) rssi %d\n", *rssi);
+        signed int dbm = (*rssi >= 128) ? (*rssi - 256) / 2 - 74 : *rssi / 2 - 74;
+        verbose("(amb8465) rssi %d (%d dBm)\n", *rssi, dbm);
     }
 
     return FullFrame;


### PR DESCRIPTION
Bugfix handling RSSI in amb8465:
* Update config RSSI_Enable = false. Was always true.
* RSSI is only in CMD_DATA_IND, not in all responses

New:
* Update rssi from last byte of transparant data
* Print rssi in dBm
* Print config UART_CMD_OUT_ENABLE
