### PR TITLE
Fix compiler warnings (fixes #119)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ endif
 
 $(info Building $(VERSION))
 
-CXXFLAGS ?= $(DEBUG_FLAGS) -fPIC -fmessage-length=0 -std=c++11 -Wall -Wno-unused-function -Wno-format-truncation
+CXXFLAGS ?= $(DEBUG_FLAGS) -fPIC -fmessage-length=0 -std=c++11 -Wall -Wno-unused-function
 CXXFLAGS += -I$(BUILD)
 
 LDFLAGS  ?= $(DEBUG_LDFLAGS)

--- a/src/meter_izar.cc
+++ b/src/meter_izar.cc
@@ -155,9 +155,9 @@ double MeterIzar::lastMonthTotalWaterConsumption(Unit u)
 
 string MeterIzar::setH0Date()
 {
-    string date;
-    strprintf(date, "%04d-%02d-%02d", h0_year, h0_month, h0_day);
-    return date;
+    char result[sizeof "65536-255-255" + 1];
+    snprintf(result, sizeof(result), "%04d-%02d-%02d", h0_year, h0_month, h0_day);
+    return result;
 }
 
 string MeterIzar::currentAlarmsText()


### PR DESCRIPTION
src/meter_izar.cc:159:49: warning: '%02d' directive output may be truncated writing between 2 and 3 bytes into a region of size between 1 and 3 [-Wformat-truncation=]
  159 |     snprintf(result, sizeof(result), "%04d-%02d-%02d", h0_year, h0_month, h0_day);
      |                                                 ^~~~
src/meter_izar.cc:159:38: note: directive argument in the range [0, 255]
  159 |     snprintf(result, sizeof(result), "%04d-%02d-%02d", h0_year, h0_month, h0_day);
      |                                      ^~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:872,
                 from /usr/include/c++/10/cstdio:42,
                 from /usr/include/c++/10/ext/string_conversions.h:43,
                 from /usr/include/c++/10/bits/basic_string.h:6535,
                 from /usr/include/c++/10/string:55,
                 from src/util.h:23,
                 from src/meters.h:21,
                 from src/meter_izar.cc:18:
/usr/include/bits/stdio2.h:70:35: note: '__builtin___snprintf_chk' output between 11 and 14 bytes into a destination of size 11

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>