### PR TITLE
Switch to ubuntu 18.04LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+dist: bionic
 
 os:
   - linux

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ endif
 
 $(info Building $(VERSION))
 
-CXXFLAGS ?= $(DEBUG_FLAGS) -fPIC -fmessage-length=0 -std=c++11 -Wall -Wno-unused-function
+CXXFLAGS ?= $(DEBUG_FLAGS) -fPIC -std=c++11 -Wall -Werror=format-security
 CXXFLAGS += -I$(BUILD)
 
 LDFLAGS  ?= $(DEBUG_LDFLAGS)


### PR DESCRIPTION
Update compiler options:
 - remove -fmessage-length=0 as it's default,
 - remove -Wno-unused-function - does not introduce any new warnings,
 - add -Werror=format-security.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>