### PR TITLE
Support Multical403 in key import

### DIFF
--- a/utils/kem-import.py
+++ b/utils/kem-import.py
@@ -23,6 +23,7 @@
 from __future__ import print_function
 import os
 import sys
+import re
 import errno
 import argparse
 import base64
@@ -136,7 +137,8 @@ if (not args.dryrun) and (not os.path.exists(args.config)):
 
 # parse the decrypted KEM file content and create corresponding meter files in 
 # wmbusmeters' config folder for each meter found in the XML file
-xmldoc = minidom.parseString(decryptedtext)
+trimmedText = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\xff]', '', decryptedtext.decode('utf-8'))
+xmldoc = minidom.parseString(trimmedText)
 for e in xmldoc.getElementsByTagName('Meter'):
     # read information from source XML file 
     meterName   = e.getElementsByTagName('MeterName')[0].firstChild.nodeValue
@@ -153,6 +155,8 @@ for e in xmldoc.getElementsByTagName('Meter'):
     # if their identification in KEM file is known
     if (meterName == 'MC302') and (meterModel.startswith('302T')): 
         wmbusmeters_driver = 'multical302'
+    elif (meterName == 'MC403') and (meterModel.startswith('403')):
+        wmbusmeters_driver = 'multical403'
     elif (meterName == 'MC21') and (meterModel.startswith('021')): 
         wmbusmeters_driver = 'multical21'
     else:


### PR DESCRIPTION
Added Multical403 (from separate pull request) support.
Trim XML output to prevent parsing errors due to additional whitespace from MyKamstrup export format.