### PR TITLE
Fix abort in detectRC1180

### DIFF
--- a/src/wmbus_rc1180.cc
+++ b/src/wmbus_rc1180.cc
@@ -341,7 +341,7 @@ AccessCheck detectRC1180(Detected *detected, shared_ptr<SerialCommunicationManag
     usleep(200*1000);
     serial->receive(&data);
 
-    if (data[0] != '>')
+    if (!data.empty() && data[0] != '>')
     {
        // no RC1180 device detected
        serial->close();


### PR DESCRIPTION
Fixes the following crash:

 Thread 1 "wmbusmeters" received signal SIGABRT, Aborted.
 [Switching to Thread 0x7ffff7a16e00 (LWP 33345)]
 0x00007ffff7a9d9e5 in raise () from /lib64/libc.so.6
 (gdb) bt
 #0  0x00007ffff7a9d9e5 in raise () from /lib64/libc.so.6
 #1  0x00007ffff7a86895 in abort () from /lib64/libc.so.6
 #2  0x00005555555962cc in std::__replacement_assert (__file=0x5555556af910 "/usr/include/c++/10/bits/stl_vector.h", __line=1045,
     __function=0x5555556af7f0 "std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = unsigned char; _Alloc = std::allocator<unsigned char>; std::vector<_Tp, _Alloc"...,
     __condition=0x5555556af7c0 "__builtin_expect(__n < this->size(), true)") at /usr/include/c++/10/x86_64-redhat-linux/bits/c++config.h:2560
 #3  0x000055555559dbe5 in std::vector<unsigned char, std::allocator<unsigned char> >::operator[] (this=0x7fffffffd9e0, __n=0) at /usr/include/c++/10/bits/stl_vector.h:1045
 #4  0x000055555569191f in detectRC1180 (detected=0x7fffffffdba0, manager=std::shared_ptr<SerialCommunicationManager> (use count 3, weak count 0) = {...}) at src/wmbus_rc1180.cc:344
 #5  0x0000555555674e7c in detectWMBusDeviceOnTTY (tty="/dev/ttyS0", handler=std::shared_ptr<SerialCommunicationManager> (use count 3, weak count 0) = {...}) at src/wmbus.cc:4201
 #6  0x00005555556a1d3c in perform_auto_scan_of_serial_devices (config=0x555555769790) at src/main.cc:870
 #7  0x00005555556a1b11 in perform_auto_scan_of_devices (config=0x555555769790) at src/main.cc:845
 #8  0x00005555556997d3 in detect_and_configure_wmbus_devices (config=0x555555769790) at src/main.cc:557
 #9  0x00005555556a322a in start (config=0x555555769790) at src/main.cc:1104
 #10 0x0000555555694796 in main (argc=3, argv=0x7fffffffe228) at src/main.cc:192
 (gdb) fr 4
 #4  0x000055555569191f in detectRC1180 (detected=0x7fffffffdba0, manager=std::shared_ptr<SerialCommunicationManager> (use count 3, weak count 0) = {...}) at src/wmbus_rc1180.cc:344
 344	    if (data[0] != '>')
 (gdb) p data
 $1 = std::vector of length 0, capacity 1024

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>