### PR TITLE
Use sh instead of bash to support systems without bash

### DIFF
--- a/tests/test_pipe.sh
+++ b/tests/test_pipe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PROG="$1"
 


### PR DESCRIPTION
One of the test files was still using `/bin/bash` as base interpreter. Change it to `/bin/sh` to support systems without bash.