### PR TITLE
Fix rtl_sdr invalid option

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1603,7 +1603,7 @@ bool check_if_rtlsdr_exists_in_path()
     bool found = false;
     vector<string> args;
     args.push_back("-c");
-    args.push_back("rtl_sdr --help < /dev/null");
+    args.push_back("rtl_sdr < /dev/null");
     vector<string> envs;
     string out;
     invokeShellCaptureOutput("/bin/sh", args, envs, &out, true);


### PR DESCRIPTION
Fixes the following invalid option in the log:

 (shell) exec (capture output) "/bin/sh"
 (shell) wmbusmetersd[8259]: (shell) arg "-c"
 (shell) arg "rtl_sdr --help < /dev/null"
 (shell) output: >>>rtl_sdr: invalid option -- '-'
         rtl_sdr, an I/Q recorder for RTL2832 based DVB-T receivers

         Usage:         -f frequency_to_tune_to [Hz]
                       [-s samplerate (default: 2048000 Hz)]
                       [-d device_index (default: 0)]
                       [-g gain (default: 0 for auto)]
                       [-p ppm_error (default: 0)]
                       [-b output_block_size (default: 16 * 16384)]
                       [-n number of samples to read (default: 0, infinite)]
                       [-S force sync output (default: async)]
                       filename (a '-' dumps samples to stdout)

         <<<

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>