### PR TITLE
Fix iIllegal quoting in CSV file

### DIFF
--- a/DLMS_Flagids.csv
+++ b/DLMS_Flagids.csv
@@ -850,7 +850,7 @@ REP	Radiant Energy Solutions Pvt Ltd	India	Asia
 RES	Renesas Electronics Singapore Pte Ltd	Singapore	Asia
 RIC	Richa Equipments Pvt. Ltd.	India	Asia
 RIL	Rikken Instrumentation Limited	India	Asia
-RIM	"CJSC \""Radio and Microelectronics\"""	Russian Federation	Europe
+RIM	"CJSC \"Radio and Microelectronics\""	Russian Federation	Europe
 RIN	Rayleigh Instruments Ltd	United Kingdom	Europe
 RIT	Ritz Instrument Transformers GmbH	Germany	Europe
 RIX	Raonix Co., Ltd.	South Korea	Asia


### PR DESCRIPTION
GitHub presents this warning:
![image](https://user-images.githubusercontent.com/596867/106682037-f2b56600-65c1-11eb-85d4-dcd5cebaf6c2.png)

Apparently the illegal quoting prevents GitHub to display it properly, it should solve this problem.