### PR TITLE
Fix IZAR previous_alarms description

### DIFF
--- a/src/meter_izar.cc
+++ b/src/meter_izar.cc
@@ -130,7 +130,7 @@ MeterIzar::MeterIzar(MeterInfo &mi) :
 
     addPrint("previous_alarms", Quantity::Text,
              [&](){ return previousAlarmsText(); },
-             "Alarms currently reported by the meter.",
+             "Alarms previously reported by the meter.",
              true, true);
 
 }


### PR DESCRIPTION
izar current_alarms  and previous_alarms  have the same description:

```
$ wmbusmeters --listfields=izar
...
          current_alarms  Alarms currently reported by the meter.
         previous_alarms  Alarms currently reported by the meter.
```