### PR TITLE
Add manufacture year and serial number for SAP IZAR PRIOS devices

### DIFF
--- a/simulations/simulation_izars.txt
+++ b/simulations/simulation_izars.txt
@@ -1,19 +1,19 @@
 # Test IZAR RC 868 I R4 PL water meter telegram
 
 telegram=|1944304C72242421D401A2|013D4013DD8B46A4999C1293E582CC|
-{"media":"water","meter":"izar","name":"IzarWater","id":"21242472","total_m3":3.488,"last_month_total_m3":3.486,"last_month_measure_date":"2019-09-30","remaining_battery_life_y":14.5,"current_alarms":"meter_blocked,underflow","previous_alarms":"no_alarm","transmit_period_s":8,"timestamp":"1111-11-11T11:11:11Z"}
+{"media":"water","meter":"izar","name":"IzarWater","id":"21242472","prefix":"C19UA","serial_number":"045842","total_m3":3.488,"last_month_total_m3":3.486,"last_month_measure_date":"2019-09-30","remaining_battery_life_y":14.5,"current_alarms":"meter_blocked,underflow","previous_alarms":"no_alarm","transmit_period_s":8,"manufacture_year":"2019","timestamp":"1111-11-11T11:11:11Z"}
 
 # Test new version of IZAR
 
 telegram=|2944A511780729662366A20118001378D3B3DB8CEDD77731F25832AAF3DA8CADF9774EA673172E8C61F2|
-{"media":"water","meter":"izar","name":"IzarWater2","id":"66236629","total_m3":16.76,"last_month_total_m3":11.84,"last_month_measure_date":"2019-11-30","remaining_battery_life_y":12,"current_alarms":"no_alarm","previous_alarms":"no_alarm","transmit_period_s":8,"timestamp":"1111-11-11T11:11:11Z"}
+{"media":"water","meter":"izar","name":"IzarWater2","id":"66236629","prefix":"","serial_number":"000000","total_m3":16.76,"last_month_total_m3":11.84,"last_month_measure_date":"2019-11-30","remaining_battery_life_y":12,"current_alarms":"no_alarm","previous_alarms":"no_alarm","transmit_period_s":8,"manufacture_year":"0","timestamp":"1111-11-11T11:11:11Z"}
 
 # Yet another version of IZAR
 
 telegram=|1944A511780779194820A1|21170013355F8EDB2D03C6912B1E37
-{"media":"water","meter":"izar","name":"IzarWater3","id":"20481979","total_m3":4.366,"last_month_total_m3":0,"last_month_measure_date":"2020-12-31","remaining_battery_life_y":11.5,"current_alarms":"no_alarm","previous_alarms":"no_alarm","transmit_period_s":8,"timestamp":"1111-11-11T11:11:11Z"}
+{"media":"water","meter":"izar","name":"IzarWater3","id":"20481979","prefix":"","serial_number":"000000","total_m3":4.366,"last_month_total_m3":0,"last_month_measure_date":"2020-12-31","remaining_battery_life_y":11.5,"current_alarms":"no_alarm","previous_alarms":"no_alarm","transmit_period_s":8,"manufacture_year":"0","timestamp":"1111-11-11T11:11:11Z"}
 
 # And another izar, with a mfct specific tpl ci field a3.
 
 telegram=|1944304c9c5824210c04a363140013716577ec59e8663ab0d31c|
-{"media":"water","meter":"izar","name":"IzarWater4","id":"2124589c","total_m3":38.944,"last_month_total_m3":38.691,"last_month_measure_date":"2021-02-01","remaining_battery_life_y":10,"current_alarms":"no_alarm","previous_alarms":"no_alarm","transmit_period_s":32,"timestamp":"1111-11-11T11:11:11Z"}
+{"media":"water","meter":"izar","name":"IzarWater4","id":"2124589c","prefix":"H19CA","serial_number":"059196","total_m3":38.944,"last_month_total_m3":38.691,"last_month_measure_date":"2021-02-01","remaining_battery_life_y":10,"current_alarms":"no_alarm","previous_alarms":"no_alarm","transmit_period_s":32,"manufacture_year":"2019","timestamp":"1111-11-11T11:11:11Z"}

--- a/src/manufacturer_specificities.h
+++ b/src/manufacturer_specificities.h
@@ -58,6 +58,9 @@ enum class DiehlAddressTransformMethod {
     SAP_PRIOS_STANDARD // ?
 };
 
+// Diehl: Determines how to interpret frame
+DiehlFrameInterpretation detectDiehlFrameInterpretation(const vector<uchar>& frame);
+
 // Diehl: Is "A field" coded differently from standard?
 DiehlAddressTransformMethod mustTransformDiehlAddress(const vector<uchar>& frame);
 


### PR DESCRIPTION
IZAR radio devices on top of Sappel (SAP) water meters look as follows:

![20210204_131800_d42](https://user-images.githubusercontent.com/596867/107861134-fbb8f980-6e43-11eb-806e-8c04bcad0800.jpg)
![20210213_200101_d42](https://user-images.githubusercontent.com/596867/107861145-0a071580-6e44-11eb-8bf5-c4d240c63c37.jpg)

The telegram address of my water meter (`21315f76`) does not match anything printed on it. It's because it's a custom coding of the `H20IA` prefix (manufacturer, year, type and diameter) and serial number `012918` printed on the meter itself (not the radio device). This PR adds support of decoding this information, which makes it a lot easier to identify an IZAR meter!

```
$ ./build/wmbusmeters --ignoreduplicates  rtlwmbus:t1 izar izar '21315f76' NOKEY
izar    21315f76        H20IA   012918  10.196 m3       9.661 m3        2021-02-01      14.5 y  no_alarm        no_alarm        32 s    2020    2021-02-13 21:45.16
izar    21315f76        H20IA   012918  10.196 m3       9.661 m3        2021-02-01      14.5 y  no_alarm        no_alarm        32 s    2020    2021-02-13 21:45.52
```