### PR TITLE
Update build_ubuntu.yml

### DIFF
--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - id: INSTALL_ADDITIONAL_BUILD_DEPENDENCIES
-      run: sudo apt-get install librtlsdr-dev libusb-dev
+      run: sudo apt-get install librtlsdr-dev libusb-dev ncurses-dev 
     - id: CONFIGURE
       run: ./configure
     - id: MAKE


### PR DESCRIPTION
add dependencies that might not be needed on the current build infrastructure but are needed locally

PS: I found out it was needed here: https://github.com/weetmuts/wmbusmeters/issues/116#issuecomment-634901813 but I think most people building it will look in the according build pipeline (as long as there is not build guide)