### PR TITLE
Fix IZAR manufacture year parsing

### DIFF
--- a/simulations/simulation_izars.txt
+++ b/simulations/simulation_izars.txt
@@ -17,3 +17,8 @@ telegram=|1944A511780779194820A1|21170013355F8EDB2D03C6912B1E37
 
 telegram=|1944304c9c5824210c04a363140013716577ec59e8663ab0d31c|
 {"media":"water","meter":"izar","name":"IzarWater4","id":"2124589c","prefix":"H19CA","serial_number":"059196","total_m3":38.944,"last_month_total_m3":38.691,"last_month_measure_date":"2021-02-01","remaining_battery_life_y":10,"current_alarms":"no_alarm","previous_alarms":"no_alarm","transmit_period_s":32,"manufacture_year":"2019","timestamp":"1111-11-11T11:11:11Z"}
+
+# Another test case to ensure non-regression on manufacture year parsing
+telegram=|1944304CDEFFE420CC01A2|63120013258F907B0AFF12529AC33B|
+{"media":"water","meter":"izar","name":"IzarWater5","id":"20e4ffde","prefix":"C15SA","serial_number":"007710","total_m3":159.832,"last_month_total_m3":157.76,"last_month_measure_date":"2021-02-01","remaining_battery_life_y":9,"current_alarms":"no_alarm","previous_alarms":"no_alarm","transmit_period_s":32,"manufacture_year":"2015","timestamp":"1111-11-11T11:11:11Z"}
+

--- a/src/meter_izar.cc
+++ b/src/meter_izar.cc
@@ -247,7 +247,7 @@ void MeterIzar::processContent(Telegram *t)
 
     if (detectDiehlFrameInterpretation(frame) == DiehlFrameInterpretation::SAP_PRIOS)
     {
-        string digits = to_string((origin[7] >> 5) << 24 | origin[6] << 16 | origin[5] << 8 | origin[4]);
+        string digits = to_string((origin[7] & 0x03) << 24 | origin[6] << 16 | origin[5] << 8 | origin[4]);
         // get the manufacture year
         uint8_t yy = atoi(digits.substr(0, 2).c_str());
         manufacture_year = yy > 70 ? (1900 + yy) : (2000 + yy); // Maybe to adjust in 2070, if this code stills lives :D

--- a/tests/test_izars.sh
+++ b/tests/test_izars.sh
@@ -16,7 +16,8 @@ rm -f $LOGFILE
 METERS="IzarWater   izar        21242472 NOKEY
         IzarWater2  izar        66236629 NOKEY
         IzarWater3  izar        20481979 NOKEY
-        IzarWater4  izar        2124589c NOKEY"
+        IzarWater4  izar        2124589c NOKEY
+        IzarWater5  izar        20e4ffde NOKEY"
 
 cat simulations/simulation_izars.txt | grep '^{' > $TEST/test_expected.txt
 $PROG --format=json simulations/simulation_izars.txt $METERS > $TEST/test_output.txt 2> $TEST/test_stderr.txt
@@ -64,6 +65,11 @@ Received telegram from: 20481979
                    ver: 0x78
                 driver: izar
 Received telegram from: 2124589c
+          manufacturer: (SAP) Sappel (0x4c30)
+                  type: Water meter (0x07)
+                   ver: 0x00
+                driver: izar
+Received telegram from: 20e4ffde
           manufacturer: (SAP) Sappel (0x4c30)
                   type: Water meter (0x07)
                    ver: 0x00


### PR DESCRIPTION
I just spotted an IZAR meter built in 2031...
Obviously my parsing was wrong, I didn't keep the correct bits for the first byte (which I didn't see because it worked for my own meter).

Added a non-regression test to make sure this meter has been built in 2015.