### PR TITLE
Fix snprintf format argument

### DIFF
--- a/src/meters.cc
+++ b/src/meters.cc
@@ -404,7 +404,7 @@ string MeterCommonImplementation::unixTimestampOfUpdate()
 {
     char ut[40];
     memset(ut, 0, sizeof(ut));
-    snprintf(ut, sizeof(ut)-1, "%zu", datetime_of_update_);
+    snprintf(ut, sizeof(ut)-1, "%lu", datetime_of_update_);
     return string(ut);
 }
 


### PR DESCRIPTION
Fixes the following compilation error:

src/meters.cc: In member function
  'virtual std::string MeterCommonImplementation::unixTimestampOfUpdate()':
src/meters.cc:407:35: warning: format '%zu' expects argument of type 'size_t',
  but argument 4 has type 'time_t' {aka 'long int'} [-Wformat=]
  407 |     snprintf(ut, sizeof(ut)-1, "%zu", datetime_of_update_);
      |                                 ~~^   ~~~~~~~~~~~~~~~~~~~
      |                                   |   |
      |                                   |   time_t {aka long int}
      |                                   unsigned int
      |                                 %lu
RPM build errors:
error: Bad exit status from /var/tmp/rpm-tmp.9tme28 (%build)
    Bad exit status from /var/tmp/rpm-tmp.9tme28 (%build)
Child return code was: 1