### PR TITLE
Fix FUZZING definition

### DIFF
--- a/src/wmbus.cc
+++ b/src/wmbus.cc
@@ -34,6 +34,10 @@
 #include<deque>
 #include<algorithm>
 
+#ifndef FUZZING
+#define FUZZING false
+#endif
+
 struct LinkModeInfo
 {
     LinkMode mode;


### PR DESCRIPTION
When build environemnt (e.g. Linux distribution) redefines
CXXFLAGS the following error can be observed. Fix this by
adding a default value for FUZZING.


src/wmbus.cc: In member function 'bool Telegram::parseELL(std::vector<unsigned char>::iterator&)':
src/wmbus.cc:989:37: error: 'FUZZING' was not declared in this scope
  989 |         if (ell_pl_crc != check && !FUZZING)
      |                                     ^~~~~~~
src/wmbus.cc: In member function 'bool Telegram::potentiallyDecrypt(std::vector<unsigned char>::iterator&)':
src/wmbus.cc:1398:56: error: 'FUZZING' was not declared in this scope
 1398 |         if ((*(pos+0) != 0x2f || *(pos+1) != 0x2f) && !FUZZING)
      |                                                        ^~~~~~~
src/wmbus.cc:1456:56: error: 'FUZZING' was not declared in this scope
 1456 |         if ((*(pos+0) != 0x2f || *(pos+1) != 0x2f) && !FUZZING)
      |                                                        ^~~~~~~
src/wmbus.cc: In function 'bool trimCRCsFrameFormatA(std::vector<unsigned char>&)':
src/wmbus.cc:4066:35: error: 'FUZZING' was not declared in this scope
 4066 |     if (calc_crc != check_crc && !FUZZING)
      |                                   ^~~~~~~
src/wmbus.cc:4080:39: error: 'FUZZING' was not declared in this scope
 4080 |         if (calc_crc != check_crc && !FUZZING)
      |                                       ^~~~~~~
src/wmbus.cc:4096:39: error: 'FUZZING' was not declared in this scope
 4096 |         if (calc_crc != check_crc && !FUZZING)
      |                                       ^~~~~~~
src/wmbus.cc: In function 'bool trimCRCsFrameFormatB(std::vector<unsigned char>&)':
src/wmbus.cc:4143:35: error: 'FUZZING' was not declared in this scope
 4143 |     if (calc_crc != check_crc && !FUZZING)
      |                                   ^~~~~~~
src/wmbus.cc:4157:39: error: 'FUZZING' was not declared in this scope
 4157 |         if (calc_crc != check_crc && !FUZZING)
      |                                       ^~~~~~~
make: *** [Makefile:106: build/wmbus.o] Error 1