### PR TITLE
Added voltages for amiplus meters

### DIFF
--- a/simulations/simulation_t1.txt
+++ b/simulations/simulation_t1.txt
@@ -29,8 +29,15 @@ telegram=|1844AE4C4455223368077A55000000|041389E20100023B0000|
 # Test amiplus/apator electricity meter
 
 telegram=|4E4401061010101002027A00004005|2F2F0E035040691500000B2B300300066D00790C7423400C78371204860BABC8FC100000000E833C8074000000000BAB3C0000000AFDC9FC0136022F2F2F2F2F|
-{"media":"electricity","meter":"amiplus","name":"MyElectricity1","id":"10101010","total_energy_consumption_kwh":15694.05,"current_power_consumption_kw":0.33,"total_energy_production_kwh":7.48,"current_power_production_kw":0,"voltage_at_phase_1_v":236,"device_date_time":"2019-03-20 12:57","timestamp":"1111-11-11T11:11:11Z"}
-|MyElectricity1;10101010;15694.050000;0.330000;7.480000;0.000000;236.000000;1111-11-11 11:11.11
+{"media":"electricity","meter":"amiplus","name":"MyElectricity1","id":"10101010","total_energy_consumption_kwh":15694.05,"current_power_consumption_kw":0.33,"total_energy_production_kwh":7.48,"current_power_production_kw":0,"voltage_at_phase_1_v":236,"voltage_at_phase_2_v":nan,"voltage_at_phase_3_v":nan,"device_date_time":"2019-03-20 12:57","timestamp":"1111-11-11T11:11:11Z"}
+|MyElectricity1;10101010;15694.050000;0.330000;7.480000;0.000000;236.000000;nan;nan;1111-11-11 11:11.11
+
+# Test amiplus/apator electricity meter with three phase voltages
+
+telegram=|5E44B6105843250000027A2A005005|2F2F0C7835221400066D404708AC2A400E032022650900000E833C0000000000001B2B9647000B2B5510000BAB3C0000000AFDC9FC0135020AFDC9FC0245020AFDC9FC0339020BABC8FC100000002F2F|
+{"media":"electricity","meter":"amiplus","name":"MyElectricity2","id":"00254358","total_energy_consumption_kwh":9652.22,"current_power_consumption_kw":1.055,"total_energy_production_kwh":0,"current_power_production_kw":0,"voltage_at_phase_1_v":235,"voltage_at_phase_2_v":245,"voltage_at_phase_3_v":239,"device_date_time":"2021-10-12 08:07","timestamp":"1111-11-11T11:11:11Z"}
+|MyElectricity2;00254358;9652.220000;1.055000;0.000000;0.000000;235.000000;245.000000;239.000000;1111-11-11 11:11.11
+
 
 # Test MKRadio3 T1 telegrams
 

--- a/src/meter_amiplus.cc
+++ b/src/meter_amiplus.cc
@@ -76,6 +76,16 @@ MeterAmiplus::MeterAmiplus(MeterInfo &mi) :
 	     "Voltage at phase L1.",
 	     true, true);
 
+    addPrint("voltage_at_phase_2", Quantity::Voltage,
+	     [&](Unit u){ return convert(voltage_L_[1], Unit::Volt, u); },
+	     "Voltage at phase L2.",
+	     true, true);
+
+    addPrint("voltage_at_phase_3", Quantity::Voltage,
+	     [&](Unit u){ return convert(voltage_L_[2], Unit::Volt, u); },
+	     "Voltage at phase L3.",
+	     true, true);
+
     addPrint("device_date_time", Quantity::Text,
              [&](){ return device_date_time_; },
              "Device date time.",
@@ -140,6 +150,19 @@ void MeterAmiplus::processContent(Telegram *t)
     voltage_L_[0] = ((double)tmpvolt);
     t->addMoreExplanation(offset, " voltage L1 (%f volts)", voltage_L_[0]);
     }
+
+    if (extractDVlong(&t->values, "0AFDC9FC02", &offset, &tmpvolt))
+    {
+    voltage_L_[1] = ((double)tmpvolt);
+    t->addMoreExplanation(offset, " voltage L2 (%f volts)", voltage_L_[1]);
+    }
+
+    if (extractDVlong(&t->values, "0AFDC9FC03", &offset, &tmpvolt))
+    {
+    voltage_L_[2] = ((double)tmpvolt);
+    t->addMoreExplanation(offset, " voltage L3 (%f volts)", voltage_L_[2]);
+    }
+        
 
     if (findKey(MeasurementType::Unknown, ValueInformation::DateTime, 0, 0, &key, &t->values)) {
         struct tm datetime;

--- a/tests/test_t1_meters.sh
+++ b/tests/test_t1_meters.sh
@@ -14,6 +14,7 @@ METERS="MyWarmWater supercom587 12345678 NOKEY
       MoreWater   iperl       12345699 NOKEY
       WaterWater  iperl       33225544 NOKEY
       MyElectricity1 amiplus  10101010 NOKEY
+      MyElectricity2 amiplus  00254358 NOKEY
       Duschen     mkradio3    34333231 NOKEY
       Duschagain  mkradio4    02410120 NOKEY
       HeatMeter   vario451    58234965 NOKEY


### PR DESCRIPTION
Hi, added voltages for amiplus electricity meters for phases 1, 2 and 3. Additionally added new extended telegram (including voltages for all 3 phases) to simulation_t1.txt. The original telegram had voltage for only one phase. Side effect is that the original one displays now "nan" for missing phase voltages, similarly to what is happening to Gran-System-S electricity meter 101. Not sure if it's possible to somehow exclude unneeded data from json?