### PR TITLE
amiplus and gransystsems - change NAN to 0 for nonexistent values

### DIFF
--- a/simulations/simulation_t1.txt
+++ b/simulations/simulation_t1.txt
@@ -29,8 +29,8 @@ telegram=|1844AE4C4455223368077A55000000|041389E20100023B0000|
 # Test amiplus/apator electricity meter
 
 telegram=|4E4401061010101002027A00004005|2F2F0E035040691500000B2B300300066D00790C7423400C78371204860BABC8FC100000000E833C8074000000000BAB3C0000000AFDC9FC0136022F2F2F2F2F|
-{"media":"electricity","meter":"amiplus","name":"MyElectricity1","id":"10101010","total_energy_consumption_kwh":15694.05,"current_power_consumption_kw":0.33,"total_energy_production_kwh":7.48,"current_power_production_kw":0,"voltage_at_phase_1_v":236,"voltage_at_phase_2_v":nan,"voltage_at_phase_3_v":nan,"device_date_time":"2019-03-20 12:57","timestamp":"1111-11-11T11:11:11Z"}
-|MyElectricity1;10101010;15694.050000;0.330000;7.480000;0.000000;236.000000;nan;nan;1111-11-11 11:11.11
+{"media":"electricity","meter":"amiplus","name":"MyElectricity1","id":"10101010","total_energy_consumption_kwh":15694.05,"current_power_consumption_kw":0.33,"total_energy_production_kwh":7.48,"current_power_production_kw":0,"voltage_at_phase_1_v":236,"voltage_at_phase_2_v":0,"voltage_at_phase_3_v":0,"device_date_time":"2019-03-20 12:57","timestamp":"1111-11-11T11:11:11Z"}
+|MyElectricity1;10101010;15694.050000;0.330000;7.480000;0.000000;236.000000;0.000000;0.000000;1111-11-11 11:11.11
 
 # Test amiplus/apator electricity meter with three phase voltages
 
@@ -235,8 +235,8 @@ telegram=|aa4424347677787950077ac10000202f2f041306070000046d1e31b12104fd17000000
 
 # Test Gran-System-S electricity meter 101
 telegram=||7844731e78610418010278046d0f13bc21040394030000841003690300008420032b00000084300300000000848010030000000084016d0000bc2184010394030000841103690300008421032b00000084310300000000848110030000000004fd482e09000004fd5b0000000002fb2d861304fd1700000201|
-{"media":"electricity","meter":"gransystems","name":"Gran101","id":"18046178","total_energy_consumption_kwh":0.916,"voltage_at_phase_1_v":235,"voltage_at_phase_2_v":nan,"voltage_at_phase_3_v":nan,"currrent_at_phase_1_a":0,"currrent_at_phase_2_a":nan,"currrent_at_phase_3_a":nan,"frequency_hz":49.98,"status":"OK","timestamp":"1111-11-11T11:11:11Z"}
-|Gran101;18046178;0.916000;235.000000;nan;nan;0.000000;nan;nan;49.980000;OK;1111-11-11 11:11.11
+{"media":"electricity","meter":"gransystems","name":"Gran101","id":"18046178","total_energy_consumption_kwh":0.916,"voltage_at_phase_1_v":235,"voltage_at_phase_2_v":0,"voltage_at_phase_3_v":0,"currrent_at_phase_1_a":0,"currrent_at_phase_2_a":0,"currrent_at_phase_3_a":0,"frequency_hz":49.98,"status":"OK","timestamp":"1111-11-11T11:11:11Z"}
+|Gran101;18046178;0.916000;235.000000;0.000000;0.000000;0.000000;0.000000;0.000000;49.980000;OK;1111-11-11 11:11.11
 
 # Test Gran-System-S electricity meter 301
 telegram=||9e44731e17011020010278046d0813bc21040300000000841003000000008420030000000084300300000000848010030000000084016d0000bc218401030000000084110300000000842103000000008431030000000084811003000000008440fd4825090000848040fd480000000084c040fd48000000008440fd5b00000000848040fd5b0000000084c040fd5b0000000002fb2d881304fd1700000101|

--- a/src/meter_amiplus.cc
+++ b/src/meter_amiplus.cc
@@ -21,7 +21,6 @@
 #include"wmbus.h"
 #include"wmbus_utils.h"
 #include"util.h"
-#include<cmath>
 
 struct MeterAmiplus : public virtual ElectricityMeter, public virtual MeterCommonImplementation {
     MeterAmiplus(MeterInfo &mi);
@@ -39,7 +38,7 @@ private:
     double current_power_kw_ {};
     double total_energy_returned_kwh_ {};
     double current_power_returned_kw_ {};
-    double voltage_L_[3]{NAN, NAN, NAN};
+    double voltage_L_[3]{0, 0, 0};
 
     string device_date_time_;
 };
@@ -142,7 +141,7 @@ void MeterAmiplus::processContent(Telegram *t)
     extractDVdouble(&t->values, "0BAB3C", &offset, &current_power_returned_kw_);
     t->addMoreExplanation(offset, " current power returned (%f kw)", current_power_returned_kw_);
 
-    voltage_L_[0]=voltage_L_[1]=voltage_L_[2] = NAN;
+    voltage_L_[0]=voltage_L_[1]=voltage_L_[2] = 0;
     uint64_t tmpvolt {};
 
     if (extractDVlong(&t->values, "0AFDC9FC01", &offset, &tmpvolt))

--- a/src/meter_gransystems_ccx01.cc
+++ b/src/meter_gransystems_ccx01.cc
@@ -44,7 +44,6 @@ Encryption: None.
 #include"wmbus.h"
 #include"wmbus_utils.h"
 #include"util.h"
-#include<cmath>
 
 struct MeterGransystemsCCx01: public virtual ElectricityMeter, public virtual MeterCommonImplementation {
     MeterGransystemsCCx01(MeterInfo &mi);
@@ -67,9 +66,9 @@ private:
     std::size_t last_day_tariff_energy_kwh_idx_{};
     double last_day_tariff_energy_kwh_[MAX_TARIFFS] {};
 
-    double voltage_L_[3]{NAN, NAN, NAN};
-    double current_L_[3]{NAN, NAN, NAN};
-    double frequency_{NAN};
+    double voltage_L_[3]{0, 0, 0};
+    double current_L_[3]{0, 0, 0};
+    double frequency_{0};
 
     bool single_phase_{};
     bool three_phase_{};
@@ -207,8 +206,8 @@ void MeterGransystemsCCx01::processContent(Telegram *t)
         }
     }
 
-    voltage_L_[0] = voltage_L_[1] = voltage_L_[2] = NAN;
-    current_L_[0]  = current_L_[1]  = current_L_[2] = NAN;
+    voltage_L_[0] = voltage_L_[1] = voltage_L_[2] = 0;
+    current_L_[0]  = current_L_[1]  = current_L_[2] = 0;
 
     if (single_phase_)
     {


### PR DESCRIPTION
amiplus and gransystems electricity meters - change NAN to 0 for nonexistent values to increase downstream compatibility.
fixes  #361