### PR TITLE
Honor the env in child processes

### DIFF
--- a/src/shell.cc
+++ b/src/shell.cc
@@ -59,7 +59,7 @@ void invokeShell(string program, vector<string> args, vector<string> envs)
 #if (defined(__APPLE__) && defined(__MACH__)) || defined(__FreeBSD__)
         execve(program.c_str(), (char*const*)&argv[0], (char*const*)&env[0]);
 #else
-        execvpe(program.c_str(), (char*const*)&argv[0], (char*const*)&env[0]);
+        execvp(program.c_str(), (char*const*)&argv[0]);
 #endif
 
         perror("Execvp failed:");
@@ -135,7 +135,7 @@ bool invokeBackgroundShell(string program, vector<string> args, vector<string> e
 #if (defined(__APPLE__) && defined(__MACH__)) || defined(__FreeBSD__)
         execve(program.c_str(), (char*const*)&argv[0], (char*const*)&env[0]);
 #else
-        execvpe(program.c_str(), (char*const*)&argv[0], (char*const*)&env[0]);
+        execvp(program.c_str(), (char*const*)&argv[0]);
 #endif
 
         perror("Execvp failed:");
@@ -270,7 +270,7 @@ int invokeShellCaptureOutput(string program, vector<string> args, vector<string>
 #if (defined(__APPLE__) && defined(__MACH__)) || defined(__FreeBSD__)
         execve(program.c_str(), (char*const*)&argv[0], (char*const*)&env[0]);
 #else
-        execvpe(program.c_str(), (char*const*)&argv[0], (char*const*)&env[0]);
+        execvp(program.c_str(), (char*const*)&argv[0]);
 #endif
 
         perror("Execvp failed:");


### PR DESCRIPTION
fixes #380: execvpe replaces the original env with the given array. The
array was empty effectivly removing PATH from the subshell. Thus
rtl_wmbus is not found, even if located within the PATH, as stated in
the documentation.