### PR TITLE
Fix: fixed typo in meter_qheat.cc

### DIFF
--- a/src/meter_qheat.cc
+++ b/src/meter_qheat.cc
@@ -72,7 +72,7 @@ MeterQHeat::MeterQHeat(MeterInfo &mi) :
              "The total energy consumption recorded at the last day of the previous month.",
              true, true);
 
-    addPrint("las_year_date", Quantity::Text,
+    addPrint("last_year_date", Quantity::Text,
              [&](){ return last_year_date_; },
              "Last day previous year when total energy consumption was recorded.",
              false, true);


### PR DESCRIPTION
While testing wmbusmeters, i noticed a small typo in my output log.
Instead of last_year_date it was printing las_year_date. This is
now fixed.