### PR TITLE
Fix oneshot when more than one meter is defined but has not been started yet

### DIFF
--- a/src/meters.cc
+++ b/src/meters.cc
@@ -149,6 +149,8 @@ public:
 
     bool hasAllMetersReceivedATelegram()
     {
+        if (meters_.size() < meter_templates_.size()) return false;
+
         for (auto &meter : meters_)
         {
             if (meter->numUpdates() == 0) return false;


### PR DESCRIPTION
Meters get only added to meters_ once a telegram has been received. If more than one meter has been defined, the check will already trigger on the first meter that receives a telegram although the others have not even been started yet.

I think this should fix it.