### PR TITLE
escape command substitution for logrotate

### DIFF
--- a/scripts/prepare_logfiles.sh
+++ b/scripts/prepare_logfiles.sh
@@ -32,7 +32,7 @@ then
     compress
     missingok
     postrotate
-        /bin/kill -HUP `cat /run/wmbusmeters/wmbusmeters.pid 2> /dev/null` 2> /dev/null || true
+        /bin/kill -HUP \`cat /run/wmbusmeters/wmbusmeters.pid 2> /dev/null\` 2> /dev/null || true
     endscript
 EOF
     echo "logrotate: created $ROOT/etc/logrotate.d/wmbusmeters"


### PR DESCRIPTION
The command `cat /run/wmbusmeters/wmbusmeters.pid 2> /dev/null` in `scripts/prepare_logfiles` wasn't escaped. So the resulting logrotate file had a broken postrotate command
```
postrotate
        /bin/kill -HUP  2> /dev/null || true
```
This made wmbusmetersd hang after logrotate moved the logfile