### PR TITLE
Allow CMD for CUL device

### DIFF
--- a/src/wmbus_cul.cc
+++ b/src/wmbus_cul.cc
@@ -85,7 +85,6 @@ private:
 shared_ptr<WMBus> openCUL(Detected detected, shared_ptr<SerialCommunicationManager> manager, shared_ptr<SerialDevice> serial_override)
 {
     string bus_alias =  detected.specified_device.bus_alias;
-    string device = detected.found_file;
     if (serial_override)
     {
         WMBusCUL *imp = new WMBusCUL(bus_alias, serial_override, manager);
@@ -93,7 +92,22 @@ shared_ptr<WMBus> openCUL(Detected detected, shared_ptr<SerialCommunicationManag
         return shared_ptr<WMBus>(imp);
     }
 
-    auto serial = manager->createSerialDeviceTTY(device.c_str(), 38400, PARITY::NONE, "cul");
+	if (detected.specified_device.command != "")
+	{
+		string identifier = "cmd_" + to_string(detected.specified_device.index);
+
+		vector<string> args;
+		vector<string> envs;
+		args.push_back("-c");
+		args.push_back(detected.specified_device.command);
+
+		auto serial = manager->createSerialDeviceCommand(identifier, "/bin/sh", args, envs, "cul");
+		WMBusCUL *imp = new WMBusCUL(bus_alias, serial, manager);
+		return shared_ptr<WMBus>(imp);
+	}
+
+	string device = detected.found_file;
+	auto serial = manager->createSerialDeviceTTY(device.c_str(), 38400, PARITY::NONE, "cul");
     WMBusCUL *imp = new WMBusCUL(bus_alias, serial, manager);
     return shared_ptr<WMBus>(imp);
 }


### PR DESCRIPTION
The existing code required WMBusCUL to use a TTY, but with the change in this pull request, it can also be a command.

## My use case

I have CUNO, i.e. a device on the network with a culfw that listens on TCP port 2323 and provides over TCP the same interface that a USB-style CUL provides via the USB serial tty. With this code change I use it with this device specification:
`cul:c1:CMD(/usr/share/cuno-connect.sh)` , where cuno-connect contains the `socat TCP:CUNO:2323 STDIO` (I couldn't execute the socat command directly in the device specification because of the colons).

This might also be a nice approach to use CULs in remote locations, when using socat on both systems.

## Alternative approach with PTYs that did not work for me

I first tried to provide my CUNO to wmbusmeters by executing socat PTY TCP:CUNO:2323, which makes the CUNO available as a Pseudo TTY, but this did not work in my docker instance, possibly because for some reason the PTYs mixed in some strange way (I received CUNO answers on one PTY that was previously connected to a shell session and had to send commands on some other PTY). It did not work.

