### PR TITLE
Add bash to docker image builders

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM multiarch/alpine:amd64-latest-stable AS build
-RUN apk add --no-cache alpine-sdk gcc linux-headers ncurses-dev librtlsdr-dev cmake libusb-dev
+RUN apk add --no-cache alpine-sdk gcc linux-headers ncurses-dev librtlsdr-dev cmake libusb-dev bash
 RUN git clone https://github.com/weetmuts/wmbusmeters.git && \
     git clone https://github.com/weetmuts/rtl-wmbus.git && \
     git clone https://github.com/merbanan/rtl_433.git

--- a/docker/Dockerfile.arm64v8
+++ b/docker/Dockerfile.arm64v8
@@ -1,5 +1,5 @@
 FROM multiarch/alpine:arm64-latest-stable AS build
-RUN apk add --no-cache alpine-sdk gcc linux-headers ncurses-dev librtlsdr-dev cmake libusb-dev
+RUN apk add --no-cache alpine-sdk gcc linux-headers ncurses-dev librtlsdr-dev cmake libusb-dev bash
 RUN git clone https://github.com/weetmuts/wmbusmeters.git && \
     git clone https://github.com/weetmuts/rtl-wmbus.git && \
     git clone https://github.com/merbanan/rtl_433.git

--- a/docker/Dockerfile.armhf
+++ b/docker/Dockerfile.armhf
@@ -1,5 +1,5 @@
 FROM multiarch/alpine:armhf-latest-stable AS build
-RUN apk add --no-cache alpine-sdk gcc linux-headers ncurses-dev librtlsdr-dev cmake libusb-dev
+RUN apk add --no-cache alpine-sdk gcc linux-headers ncurses-dev librtlsdr-dev cmake libusb-dev bash
 RUN git clone https://github.com/weetmuts/wmbusmeters.git && \
     git clone https://github.com/weetmuts/rtl-wmbus.git && \
     git clone https://github.com/merbanan/rtl_433.git


### PR DESCRIPTION
CI was failing on `generate_authors.sh` thus preventing builds for Docker. I've managed to find that the issue is due to lack of Bash in default Alpine Linux images used for Docker builds. This PR adds bash to all Dockerfiles. Hope it helps!