### PR TITLE
Update auto discover for HA

### DIFF
--- a/ha-addon/config.json
+++ b/ha-addon/config.json
@@ -20,7 +20,7 @@
     "options": {
         "data_path": "/config/wmbusmeters",
         "conf":
-            "loglevel=normal\ndevice=/dev/ttyUSB0:t1\nlogtelegrams=false\nformat=json\nlogfile=/dev/stdout\nshell=/wmbusmeters/mosquitto_pub.sh wmbusmeters/$METER_NAME \"$METER_JSON\"",
+            "loglevel=normal\ndevice=auto:t1\ndonotprobe=/dev/ttyAMA0\nlogtelegrams=false\nformat=json\nlogfile=/dev/stdout\nshell=/wmbusmeters/mosquitto_pub.sh wmbusmeters/$METER_NAME \"$METER_JSON\"",
         "meters": [],
         "mqtt": {}
     },


### PR DESCRIPTION
- Change the device to use auto discovery
- Don't probe /dev/ttyAMA0 that upsets Raspberry PIs

After the changes in this PR I could see on my setup:
```
[...]
Running wmbusmeters ...
No wmbus device detected, waiting for a device to be plugged in.
No meters configured. Printing id:s of all telegrams heard!
```
Then I plugged in my dongle and...

```
Started auto rtlwmbus[00000001] listening on t1
Received telegram from: [redacted]
          manufacturer: (KAM) Kamstrup Energi (0x2c2d)
                  type: Cold water meter (0x16) encrypted
```

From README.md
```
It is recommended that you use auto to find your dongle, then, when you know the exact device path, you write for example: device=/dev/ttyUSB0:im871a:c1,t1 in the configuration file or on the command line. This will skip the slow probing for all possible dongles when wmbusmeters starts up.

If you have to scan serial devices, then remember that some Raspberry PIs are upset when random data is sent to /dev/ttyAMA0 when it is configured in bluetooth mode. To solve this, add donotprobe=/dev/ttyAMA0
```

cc: @to-masz @rafalstarczak @weetmuts 