### PR TITLE
Update config.json

### DIFF
--- a/ha-addon/config.json
+++ b/ha-addon/config.json
@@ -6,6 +6,7 @@
     "arch": ["armv7", "aarch64", "amd64"],
     "url": "https://github.com/weetmuts/wmbusmeters",
     "startup": "application",
+    "init": false,
     "boot": "auto",
     "devices": ["/dev/ttyUSB0", "/dev/ttyAMA0"],
     "usb": true,


### PR DESCRIPTION
Adding "init": false, to ha addon configuration to avoid "s6-overlay-suexec: fatal: can only run as pid 1"