### PR TITLE
Enable CI on all branches

### DIFF
--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -1,9 +1,7 @@
 name: Build Ubuntu
 on:
   push:
-    branches:
-      - master
-      - 'debug/**'
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Enables CI on every branch to make it usable on
pull requests and forked repositories.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>