### PR TITLE
Fix compilation error on gcc 12

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -31,6 +31,7 @@
 #include<stddef.h>
 #include<string.h>
 #include<string>
+#include<time.h>
 #include<errno.h>
 #include<sys/stat.h>
 #include<sys/time.h>


### PR DESCRIPTION
Fixes the following error:
  src/util.cc: In function ‘bool enableLogfile(std::string, bool)’:
  src/util.cc:379:22: error: ‘time’ was not declared in this scope; did you mean ‘utimes’?
    379 |         time_t now = time(NULL);
        |                      ^~~~

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>