### PR TITLE
MQTT discovery

### DIFF
--- a/ha-addon/Dockerfile
+++ b/ha-addon/Dockerfile
@@ -24,6 +24,9 @@ COPY --from=build /wmbusmeters/build/wmbusmeters /wmbusmeters/wmbusmeters
 COPY --from=build /rtl-wmbus/build/rtl_wmbus /usr/bin/rtl_wmbus
 COPY --from=build /rtl_433/build/src/rtl_433 /usr/bin/rtl_433
 
+COPY mqtt_discovery.sh /
+RUN chmod a+x /mqtt_discovery.sh
+
 COPY run.sh /
 RUN chmod a+x /run.sh
 

--- a/ha-addon/config.json
+++ b/ha-addon/config.json
@@ -27,6 +27,7 @@
     },
     "schema": {
         "data_path": "str",
+        "enable_mqtt_discovery": "bool?",
         "mqtt": {
           "host": "str?",
           "port": "port?",

--- a/ha-addon/config.json
+++ b/ha-addon/config.json
@@ -20,6 +20,7 @@
     ],
     "options": {
         "data_path": "/config/wmbusmeters",
+        "enable_mqtt_discovery": false,
         "conf":
             "loglevel=normal\ndevice=/dev/ttyUSB0:t1\nlogtelegrams=false\nformat=json\nlogfile=/dev/stdout\nshell=/wmbusmeters/mosquitto_pub.sh wmbusmeters/$METER_NAME \"$METER_JSON\"",
         "meters": [],

--- a/ha-addon/mqtt_discovery.sh
+++ b/ha-addon/mqtt_discovery.sh
@@ -11,18 +11,18 @@ do
     esac
 done
 
+# Get discovery_prefix
+if bashio::config.exists "mqtt.discovery_prefix"
+then MQTT_DISCOVERY_PREFIX=$(bashio::config "mqtt.discovery_prefix")
+else MQTT_DISCOVERY_PREFIX=$(bashio::services mqtt "discovery_prefix"); fi
+if [ "${MQTT_DISCOVERY_PREFIX+true}" ] || [ $MQTT_DISCOVERY_PREFIX != "null" ];
+then MQTT_DISCOVERY_PREFIX="homeassistant"; fi
+
 
 # Is MQTT discovery enabled?
 CONFIG_MQTTDISCOVERY_ENABLED="$(jq --raw-output -c -M '.enable_mqtt_discovery' $CONFIG_PATH)"
 if [ $CONFIG_MQTTDISCOVERY_ENABLED == "true" ]; then
     echo -e "\nMQTT Discovery ..."
-
-    # Get discovery_prefix
-    if bashio::config.exists "mqtt.discovery_prefix"
-    then MQTT_DISCOVERY_PREFIX=$(bashio::config "mqtt.discovery_prefix")
-    else MQTT_DISCOVERY_PREFIX=$(bashio::services mqtt "discovery_prefix"); fi
-    if [ "${MQTT_DISCOVERY_PREFIX+true}" ] || [ $MQTT_DISCOVERY_PREFIX != "null" ];
-    then MQTT_DISCOVERY_PREFIX="homeassistant"; fi
 
     # Copy template files
     templatedir="$(mktemp -d -p /dev/shm/)"

--- a/ha-addon/mqtt_discovery.sh
+++ b/ha-addon/mqtt_discovery.sh
@@ -46,7 +46,7 @@ if [ $CONFIG_MQTTDISCOVERY_ENABLED == "true" ]; then
         echo " Adding meter: ${aryKV['name']} ..."
 
         if [ "${aryKV['id']+true}" ] && [ "${aryKV['driver']+true}" ] ; then
-            file="$CONFIG_DATA_PATH/etc/discovery/${aryKV['driver']}.json"
+            file="$CONFIG_DATA_PATH/etc/mqtt_discovery/${aryKV['driver']}.json"
             if test -f "$file"; then
 
                 for attribute in $(jq --raw-output -c -M '. | keys[]' $file)

--- a/ha-addon/mqtt_discovery.sh
+++ b/ha-addon/mqtt_discovery.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/with-contenv bashio
+
+aryDiscTopic=()
+pub_args=()
+while getopts h:p:u:P:c:w: flag
+do
+    case "${flag}" in
+        h|p|u|P) pub_args+=("-${flag}" ${OPTARG});;
+        c) CONFIG_PATH=${OPTARG};;
+        w) CONFIG_DATA_PATH=${OPTARG};;
+    esac
+done
+
+
+# Is MQTT discovery enabled?
+CONFIG_MQTTDISCOVERY_ENABLED="$(jq --raw-output -c -M '.enable_mqtt_discovery' $CONFIG_PATH)"
+if [ $CONFIG_MQTTDISCOVERY_ENABLED == "true" ]; then
+    echo -e "\nMQTT Discovery ..."
+
+    # Get discovery_prefix
+    if bashio::config.exists "mqtt.discovery_prefix"
+    then MQTT_DISCOVERY_PREFIX=$(bashio::config "mqtt.discovery_prefix")
+    else MQTT_DISCOVERY_PREFIX=$(bashio::services mqtt "discovery_prefix"); fi
+    if [ "${MQTT_DISCOVERY_PREFIX+true}" ] || [ $MQTT_DISCOVERY_PREFIX != "null" ];
+    then MQTT_DISCOVERY_PREFIX="homeassistant"; fi
+
+    # Copy template files
+    templatedir="$(mktemp -d -p /dev/shm/)"
+    wget -O - https://github.com/jnxxx/wmbusmeters/archive/refs/heads/master.tar.gz 2> /dev/null | tar xz --strip=3 "wmbusmeters-master/ha-addon/mqtt_discovery" -C $templatedir || true
+    [ ! -d $CONFIG_DATA_PATH/etc/mqtt_discovery ] && mkdir -p $CONFIG_DATA_PATH/etc/mqtt_discovery
+    cp -u ${templatedir}/* ${CONFIG_DATA_PATH}/etc/mqtt_discovery/ 2>/dev/null || true
+    rm -r $templatedir
+
+    # Enumerate defined meters
+    IFS=$'\n'
+    for meter in $(jq -c -M '.meters[]' $CONFIG_PATH)
+    do 
+        declare -A aryKV
+        declare kv
+        for line in $(printf '%s\n' $meter | jq --raw-output -c -M '.')
+        do
+            readarray -d = -t kv <<< $line
+            #echo "${kv[0]}  =  ${kv[1]}"
+            aryKV[${kv[0]}]=${kv[1]%$'\n'}
+        done
+        echo " Adding meter: ${aryKV['name']} ..."
+
+        if [ "${aryKV['id']+true}" ] && [ "${aryKV['driver']+true}" ] ; then
+            file="$CONFIG_DATA_PATH/etc/discovery/${aryKV['driver']}.json"
+            if test -f "$file"; then
+
+                for attribute in $(jq --raw-output -c -M '. | keys[]' $file)
+                do
+                    #echo "Attribute: ${attribute}"
+                    aryKV["attribute"]=$attribute
+
+                    filter=".${attribute}.component"
+                    component=$(jq --raw-output -c -M $filter $file)
+                    if [[ ! -z "$component" ]] && [ $component != "null" ] ; then
+                        topic="$MQTT_DISCOVERY_PREFIX/$component/wmbusmeters/${aryKV['id']}_$attribute/config"
+
+                        filter=".${attribute}.discovery_payload"
+                        payload=$(jq --raw-output -c -M $filter $file)
+
+                        for key in ${!aryKV[@]}; do                                                              
+                            payload="${payload//\{$key\}/${aryKV[${key}]}}"
+                            #echo ${key} ${aryKV[${key}]}                                                             
+                        done
+                        echo "  Add/update topic: $topic"
+                        #echo "  Payload: $payload"
+                        aryDiscTopic+=($topic)
+                        /usr/bin/mosquitto_pub ${pub_args[@]} -r -t "${topic}" -m "${payload}"
+                    fi
+                done
+            else
+                echo "  File $file not found."
+            fi
+        fi
+    done
+
+fi
+
+echo -e "MQTT Discovery cleanup..."
+ramtmp="$(mktemp -p /dev/shm/)"
+/usr/bin/mosquitto_sub ${pub_args[@]} -t "$MQTT_DISCOVERY_PREFIX/+/wmbusmeters/+/config" --retained-only -F "%t" > $ramtmp & PID=$!
+sleep 1
+kill $PID
+
+readarray -t aryReadTopic < $ramtmp;
+rm $ramtmp
+for topic in ${aryReadTopic[@]}
+do
+    if [[ ! ${aryDiscTopic[@]} =~ $topic ]]; then
+        echo " Removing topic: $topic"
+        /usr/bin/mosquitto_pub ${pub_args[@]} -r -t "${topic}" -n
+    fi
+done
+

--- a/ha-addon/mqtt_discovery/multical21.json
+++ b/ha-addon/mqtt_discovery/multical21.json
@@ -1,0 +1,226 @@
+{
+    "total_m3": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "json_attributes_topic": "wmbusmeters/{name}",
+            "state_class": "total",
+            "name": "WaterMeter total",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "m³",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:gauge"
+        }
+    },
+
+    "target_m3": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "state_class": "total",
+            "name": "{name} target",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "m³",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:gauge"
+        }
+    },
+
+    "max_flow_m3h": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "state_class": "measurement",
+            "name": "{name} max flow",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "m³/h",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:waves-arrow-right"
+        }
+    },
+
+    "flow_temperature_c": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "availability": {
+                "topic": "wmbusmeters/{name}",
+                "value_template": "{{ value_json.{attribute} != 127 }}",
+                "payload_available": "True",
+                "payload_not_available": "False"
+            },
+            "enabled_by_default": false,
+            "state_class": "measurement",
+            "device_class": "temperature",
+            "name": "{name} water temperature",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:thermometer-water"
+        }
+    },
+
+    "external_temperature_c": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "availability": {
+                "topic": "wmbusmeters/{name}",
+                "value_template": "{{ value_json.{attribute} != 127 }}",
+                "payload_available": "True",
+                "payload_not_available": "False"
+            },
+            "enabled_by_default": false,
+            "state_class": "measurement",
+            "device_class": "temperature",
+            "name": "{name} ambient temperature",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:thermometer"
+        }
+    },
+
+    "status_dry": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "problem",
+            "name": "{name} status dry",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'DRY' in value_json.current_status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+    "status_reversed": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "problem",
+            "name": "{name} status reversed",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'REVERSED' in value_json.current_status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+    "status_leak": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "problem",
+            "name": "{name} status leak",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'LEAK' in value_json.current_status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+    "status_burst": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "problem",
+            "name": "{name} status burst",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'BURST' in value_json.current_status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+
+    "rssi_dbm": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "device_class": "signal_strength",
+            "state_class": "measurement",
+            "name": "{name} rssi",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "dbm",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:signal"
+        }
+    }
+
+}

--- a/ha-addon/mqtt_discovery/multical21.json
+++ b/ha-addon/mqtt_discovery/multical21.json
@@ -12,7 +12,7 @@
             "enabled_by_default": true,
             "json_attributes_topic": "wmbusmeters/{name}",
             "state_class": "total",
-            "name": "WaterMeter total",
+            "name": "{name} total",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "m³",

--- a/ha-addon/mqtt_discovery/multical603.json
+++ b/ha-addon/mqtt_discovery/multical603.json
@@ -118,7 +118,7 @@
                 "name": "{name}",
                 "sw_version": "{id}"
             },
-            "enabled_by_default": true,
+            "enabled_by_default": false,
             "json_attributes_topic": "wmbusmeters/{name}",
             "state_class": "total",
             "device_class": "energy",
@@ -141,7 +141,7 @@
                 "name": "{name}",
                 "sw_version": "{id}"
             },
-            "enabled_by_default": true,
+            "enabled_by_default": false,
             "json_attributes_topic": "wmbusmeters/{name}",
             "state_class": "total",
             "device_class": "energy",

--- a/ha-addon/mqtt_discovery/multical603.json
+++ b/ha-addon/mqtt_discovery/multical603.json
@@ -1,0 +1,349 @@
+{
+    "total_energy_consumption_kwh": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "json_attributes_topic": "wmbusmeters/{name}",
+            "state_class": "total",
+            "device_class": "energy",
+            "name": "{name} total energy consumption",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "kWh",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:gauge"
+        }
+    },
+
+    "total_volume_m3": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "state_class": "total",
+            "name": "{name} total volume",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "m³",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:gauge"
+        }
+    },
+
+    "volume_flow_m3h": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "state_class": "measurement",
+            "name": "{name} volume flow",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "m³/h",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:waves-arrow-right"
+        }
+    },
+
+    "t1_temperature_c": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "state_class": "measurement",
+            "device_class": "temperature",
+            "name": "{name} T1 temperature",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:thermometer-water"
+        }
+    },
+
+    "t2_temperature_c": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "state_class": "measurement",
+            "device_class": "temperature",
+            "name": "{name} T2 temperature",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:thermometer"
+        }
+    },
+
+    "energy_forward_kwh": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "json_attributes_topic": "wmbusmeters/{name}",
+            "state_class": "total",
+            "device_class": "energy",
+            "name": "{name} energy forward",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "kWh",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:gauge"
+        }
+    },
+
+    "energy_returned_kwh": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "json_attributes_topic": "wmbusmeters/{name}",
+            "state_class": "total",
+            "device_class": "energy",
+            "name": "{name} energy returned",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "kWh",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:gauge"
+        }
+    },
+
+    "status_VOLTAGE_INTERRUPTED": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "device_class": "problem",
+            "name": "{name} voltage interrupted",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'VOLTAGE_INTERRUPTED' in value_json.current_status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+    "status_LOW_BATTERY_LEVEL": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "entity_category": "diagnostic",
+            "device_class": "battery",
+            "name": "{name} low battery level",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'LOW_BATTERY_LEVEL' in value_json.current_status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+    "status_EXTERNAL_ALARM": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "device_class": "problem",
+            "name": "{name} external alarm",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'EXTERNAL_ALARM' in value_json.current_status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+    "status_SENSOR_T1_ABOVE_MEASURING_RANGE": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "device_class": "problem",
+            "name": "{name} sensor T1 above range",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'SENSOR_T1_ABOVE_MEASURING_RANGE' in value_json.current_status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+    "status_SENSOR_T2_ABOVE_MEASURING_RANGE": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "device_class": "problem",
+            "name": "{name} sensor T2 above range",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'SENSOR_T2_ABOVE_MEASURING_RANGE' in value_json.current_status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+    "status_SENSOR_T1_BELOW_MEASURING_RANGE": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "device_class": "problem",
+            "name": "{name} sensor T1 below range",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'SENSOR_T1_BELOW_MEASURING_RANGE' in value_json.current_status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+    "status_SENSOR_T2_BELOW_MEASURING_RANGE": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "device_class": "problem",
+            "name": "{name} sensor T2 below range",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'SENSOR_T2_BELOW_MEASURING_RANGE' in value_json.current_status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+    "status_TEMP_DIFF_WRONG_POLARITY": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "device_class": "problem",
+            "name": "{name} temp diff wrong polarity",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'TEMP_DIFF_WRONG_POLARITY' in value_json.current_status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+
+    "rssi_dbm": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Kamstrup",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "device_class": "signal_strength",
+            "state_class": "measurement",
+            "name": "{name} rssi",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "dbm",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:signal"
+        }
+    }
+
+}

--- a/ha-addon/mqtt_discovery/multical603.json
+++ b/ha-addon/mqtt_discovery/multical603.json
@@ -18,7 +18,7 @@
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "kWh",
             "value_template": "{{ value_json.{attribute} }}",
-            "icon": "mdi:gauge"
+            "icon": "mdi:home-lightning-bolt-outline"
         }
     },
 
@@ -39,7 +39,7 @@
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "m³",
             "value_template": "{{ value_json.{attribute} }}",
-            "icon": "mdi:gauge"
+            "icon": "mdi:water"
         }
     },
 
@@ -104,7 +104,7 @@
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "°C",
             "value_template": "{{ value_json.{attribute} }}",
-            "icon": "mdi:thermometer"
+            "icon": "mdi:thermometer-water"
         }
     },
 
@@ -127,7 +127,7 @@
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "kWh",
             "value_template": "{{ value_json.{attribute} }}",
-            "icon": "mdi:gauge"
+            "icon": "mdi:home-lightning-bolt"
         }
     },
 
@@ -150,7 +150,7 @@
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "kWh",
             "value_template": "{{ value_json.{attribute} }}",
-            "icon": "mdi:gauge"
+            "icon": "mdi:home-lightning-bolt"
         }
     },
 

--- a/ha-addon/run.sh
+++ b/ha-addon/run.sh
@@ -52,5 +52,8 @@ MESSAGE=\$2
 EOL
 chmod a+x /wmbusmeters/mosquitto_pub.sh
 
+# Running MQTT discovery
+/mqtt_discovery.sh ${pub_args[@]} -c $CONFIG_PATH -w $CONFIG_DATA_PATH
+
 echo "Running wmbusmeters ..."
 /wmbusmeters/wmbusmeters --useconfig=$CONFIG_DATA_PATH

--- a/ha-addon/run.sh
+++ b/ha-addon/run.sh
@@ -53,7 +53,7 @@ EOL
 chmod a+x /wmbusmeters/mosquitto_pub.sh
 
 # Running MQTT discovery
-/mqtt_discovery.sh ${pub_args[@]} -c $CONFIG_PATH -w $CONFIG_DATA_PATH
+/mqtt_discovery.sh ${pub_args[@]} -c $CONFIG_PATH -w $CONFIG_DATA_PATH || true
 
 echo "Running wmbusmeters ..."
 /wmbusmeters/wmbusmeters --useconfig=$CONFIG_DATA_PATH


### PR DESCRIPTION
This is a proposal for adding MQTT discovery to the HA addon.

For known meters (types that has a template file) it can automatically tell HA which sensors to create and how to read the payload.
Thus, manually adding the sensor definition to `configuration.yaml` is not needed. Rather than each user defines this, it can be done once and for all per meter and new users just get it automatically.

#### How it works:
As it is implemented in bash script it is made very simple.
It enumerates the defined meters and specificially reads the driver value. Based on the driver it reads a template file for the meter type. This file defines which sensers to create, much like the information that can manually be inserted in the configuration file. Some values are replaced, and finally it is published in MQTT and the sensers appear in HA.

Due to the dependency on the driver value, it cannot work with auto. But it seems it is not recommended for production workloads anyway.

#### Example for a simple sensor for multical21:
```
{
    "total_m3": {
        "component": "sensor",
        "discovery_payload": {
            "device": {
                "identifiers": ["wmbusmeters_{id}"],
                "manufacturer": "Kamstrup",
                "model": "{driver}",
                "name": "{name}",
                "sw_version": "{id}"
            },
            "enabled_by_default": true,
            "json_attributes_topic": "wmbusmeters/{name}",
            "state_class": "total",
            "name": "{name} total",
            "state_topic": "wmbusmeters/{name}",
            "unique_id": "wmbusmeters_{id}_{attribute}",
            "unit_of_measurement": "m³",
            "value_template": "{{ value_json.{attribute} }}",
            "icon": "mdi:gauge"
        }
    },
...
```
Curly brackets like `{driver}` is replaced with the corresponding value from the meter definition. `{attribute}` specifically does not come from the meter definition, but is just the value from the top node, in the case "total_m3". It just makes it easier to copy for reuse.

In the sensor definition I have included a device definition.
When seen from within HA it looks a lot more convincing I think, rather than just a number of unrelated sensors.

**Binary sensors**
In the first template file for multical21, I have also made some examples of binary sensors for the four warning indicators: dry, burst, leak and reversed.

**Availability**
Also it has an example of availability for the temperature readings. For example my meter read 127 all the time, and I can see in the code it does that when meter does not deliver any value. This seem to match the R value of my meters configuration. Thus, if the reading says 127 rather than showing this value it says unavailable, and for others it shows the reported value.

#### Template files source
The template files are taken directly from the repository rather than including these in the docker image.
This may not be best practice, but if it turns a success it may require quite a few additions or updates of these template files.
As the container is build locally, it puts some [wear and tear to users SD card](https://developers.home-assistant.io/docs/add-ons/publishing#locally-build-containers). Rather than cause an abundance of builds, I decided for this method (but can of course be changed). The files in mqtt_discovery are copied to ~/config/wmbusmeters/etc/mqtt_discovery where it is used from. Here it is also easy to make changes or add and test new types locally.


#### For it to work:

1. Meter must be defined with a specific driver (not auto, which isn't recommended for production anyway)
2. A template file must have been defined for the driver type.
3. MQTT discovery must be enabled in the config file.

If MQTT discovery is not enabled, cleanup will still run to remove what may have previously been published.



![image](https://user-images.githubusercontent.com/20459196/181475956-ec811ded-9b65-4c1a-83b5-81a55bc0f349.png)

![image](https://user-images.githubusercontent.com/20459196/181476006-d04ec6e0-61ed-47c8-9cf7-4e2647a5dbad.png)

![image](https://user-images.githubusercontent.com/20459196/181476040-dff94064-5a70-4a0f-b368-e986c2a45e0e.png)


cc: @to-masz @rafalstarczak @weetmuts