### PR TITLE
Keep environment in shell subprocesses

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -57,6 +57,9 @@ if [ "$?" != "0" ]; then RC="1"; fi
 tests/test_shell2.sh $PROG
 if [ "$?" != "0" ]; then RC="1"; fi
 
+tests/test_shell_env.sh $PROG
+if [ "$?" != "0" ]; then RC="1"; fi
+
 tests/test_meterfiles.sh $PROG
 if [ "$?" != "0" ]; then RC="1"; fi
 

--- a/tests/test_shell_env.sh
+++ b/tests/test_shell_env.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+PROG="$1"
+
+mkdir -p testoutput
+TEST=testoutput
+
+TESTNAME="Test shell environment"
+TESTRESULT="ERROR"
+
+export MY_ENV_TEST="hello world"
+
+$PROG --shell='echo MY_ENV_TEST="$MY_ENV_TEST"' simulations/simulation_shell.txt MWW supercom587 12345678 "" > $TEST/test_output.txt 2> $TEST/test_stderr.txt
+if [ "$?" = "0" ]
+then
+    echo 'MY_ENV_TEST=hello world' > $TEST/test_expected.txt
+    diff $TEST/test_expected.txt $TEST/test_output.txt
+    if [ "$?" = "0" ]
+    then
+        echo OK: $TESTNAME
+        TESTRESULT="OK"
+    fi
+fi
+
+if [ "$TESTRESULT" = "ERROR" ]
+then
+    echo ERROR: $TESTNAME
+    exit 1
+fi


### PR DESCRIPTION
Currently we replace the environment of subprocesses with our own,
primarily only consisting of METER_* entries. Besides clearing
some very useful system dependent variables (like PATH, LDPATH, etc.)
with also prevent the user from passing environment variables to
invoked commands.

This patch will now copy the current environment and extends it with
the variables we want to set.

---

This is essentially another take on #385 although my motivation is different. I simply wanted to pass down some configuration variables to the shell command I was running. This is now possible, while also setting the intended `METER_*` variables.