### PR TITLE
drivers: Recognize QDS/0x07/0x35 as qwater

### DIFF
--- a/ha-addon/mqtt_discovery/qwater.json
+++ b/ha-addon/mqtt_discovery/qwater.json
@@ -1,0 +1,49 @@
+{
+    "total_m3": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "Qundis",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "json_attributes_topic": "wmbusmeters/{name}",
+            "state_class": "total",
+            "name": "{name} total",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "m³",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:gauge"
+        }
+    },
+    "rssi_dbm": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "Qundis",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "device_class": "signal_strength",
+            "state_class": "measurement",
+            "name": "{name} rssi",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "dbm",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:signal"
+        }
+    }
+}

--- a/src/driver_qwater.cc
+++ b/src/driver_qwater.cc
@@ -44,6 +44,7 @@ static bool ok = registerDriver([](DriverInfo&di)
     di.addLinkMode(LinkMode::S1);
     di.addDetection(MANUFACTURER_QDS, 0x37,  0x33);
     di.addDetection(MANUFACTURER_QDS, 0x06,  0x18);
+    di.addDetection(MANUFACTURER_QDS, 0x07,  0x35);
 
     di.setConstructor([](MeterInfo& mi, DriverInfo& di){ return shared_ptr<Meter>(new MeterQWater(mi, di)); });
 });


### PR DESCRIPTION
I used to use my Q module 5.5 water with the [`lse_07_17` driver](https://github.com/weetmuts/wmbusmeters/issues/352) which worked fine. Then I noticed there's an actual `qwater` driver, which gives the same output as the other driver, but also adds 'due_date_17_m3' and 'due_date_17' fields.

I added the signature to the `qwater` driver so it can be discovered by that particular meter automatically (and that there's no more "correct driver is: unknown!" warnings in the logfile)

```bash
$ wmbusmeters --logtelegrams simulation_abc.txt 
No meters configured. Printing id:s of all telegrams heard!
^CReceived telegram from: 36682268
          manufacturer: (QDS) Qundis, Germany (0x4493)
                  type: Radio converter (meter side) (0x37)
                   ver: 0x35
      Concerning meter: 26966667
          manufacturer: (QDS) Qundis, Germany (0x4493)
                  type: Water meter (0x07)
                   ver: 0x35
                driver: qwater
telegram=|_3C449344682268363537726766962693443507720000200C13670512004C1361100300426CBF2CCC081344501100C2086CDF28326CFFFF046D0813CF29|+1
```