### PR TITLE
Full implementation for Apator E-ITN 30.51

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ Waterstar M (waterstarm)
 Zenner Minomess (minomess)
 
 Supported heat cost allocators:
+Apator E-ITN 30.51 (apatoreitn)
 Innotas EurisII  (eurisii)
 Qundis Q caloric (qcaloric)
 Sontex 868 (sontex868)


### PR DESCRIPTION
Full implementation of protocol for Apator E-ITN 30.51, as discussed in #598 

So far tested on 4 devices I have access to, and a dozen ones I don't have access but I can receive telegrams (this is how I got `esb_date` by the way)

Value for `season_start_date_` may be wrong. But this is the only part of telegram that matches season start data in any familiar format.

Not sure how to deal with date properly, including the fact that electronic seal break date may (and well, should) be `0000`.

Driver "Test" section needs to be updated, I'm not sure how to generate that?

and I guess I should add `t->addSpecialExplanation` for all fields, right?

Data example (outdated)
```
{'current_date': '2022-09-20T01:00:00Z',
 'current_hca': 0,
 'device': 'rtlwmbus[00000001]',
 'esb_date': '',
 'id': 'zzzzzzzz',
 'media': 'heat cost allocation',
 'meter': 'apatoreitn',
 'name': 'heat',
 'previous_hca': 100,
 'rssi_dbm': 9,
 'season_start_date': '2016-05-01T01:00:00Z',
 'temp_room_avg_c': 23.484375,
 'temp_room_prev_avg_c': 21.8125,
 'timestamp': '2022-09-20T11:33:10Z'}
```