### PR TITLE
added MQTT discovery for sensostar and extended statuses supported by driver

### DIFF
--- a/ha-addon/mqtt_discovery/sensostar.json
+++ b/ha-addon/mqtt_discovery/sensostar.json
@@ -172,6 +172,174 @@
         }
     },
 
+    "status_ERROR_TEMP_SENSOR_1_CABLE_BREAK": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "problem",
+            "name": "{name} status error (Temperature Sensor 1 Cable Break)",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'ERROR_TEMP_SENSOR_1_CABLE_BREAK' in value_json.status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+
+    "status_ERROR_TEMP_SENSOR_1_SHORT_CIRCUIT": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "problem",
+            "name": "{name} status error (Temperature Sensor 1 Short Circuit)",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'ERROR_TEMP_SENSOR_1_SHORT_CIRCUIT' in value_json.status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+
+    "status_ERROR_TEMP_SENSOR_2_CABLE_BREAK": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "problem",
+            "name": "{name} status error (Temperature Sensor 2 Cable Break)",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'ERROR_TEMP_SENSOR_2_CABLE_BREAK' in value_json.status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+
+    "status_ERROR_TEMP_SENSOR_2_SHORT_CIRCUIT": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "problem",
+            "name": "{name} status error (Temperature Sensor 2 Short Circuit)",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'ERROR_TEMP_SENSOR_2_SHORT_CIRCUIT' in value_json.status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+
+    "status_ERROR_FLOW_MEASUREMENT_SYSTEM_ERROR": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "problem",
+            "name": "{name} status error (Flow Management System)",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'ERROR_FLOW_MEASUREMENT_SYSTEM_ERROR' in value_json.status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+
+    "status_ERROR_ELECTRONICS_DEFECT": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "problem",
+            "name": "{name} status error (Electronics Defective)",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'ERROR_ELECTRONICS_DEFECT' in value_json.status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+
+    "status_OK_INSTRUMENT_RESET": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "problem",
+            "name": "{name} status OK (instrument reset)",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'OK_INSTRUMENT_RESET' in value_json.status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+
+    "status_OK_BATTERY_LOW": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "problem",
+            "name": "{name} status OK (battery low)",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'OK_BATTERY_LOW' in value_json.status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+
     "meter_timestamp": {
         "component": "sensor",
         "discovery_payload": {

--- a/ha-addon/mqtt_discovery/sensostar.json
+++ b/ha-addon/mqtt_discovery/sensostar.json
@@ -1,0 +1,239 @@
+{
+    "total_water_m3": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "state_class": "total",
+            "name": "{name} total water volume",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "m³",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:water"
+        }
+    },
+
+    "flow_water_m3h": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "state_class": "measurement",
+            "name": "{name} water volume flow",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "m³/h",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:waves-arrow-right"
+        }
+    },
+
+    "total_kwh": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "json_attributes_topic": "wmbusmeters/{name}",
+            "state_class": "total",
+            "device_class": "energy",
+            "name": "{name} total energy consumption",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "kWh",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:home-lightning-bolt-outline"
+        }
+    },
+
+    "power_kw": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "state_class": "measurement",
+            "name": "{name} current power consumption",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "kW",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:waves-arrow-right"
+        }
+    },
+
+    "forward_c": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "state_class": "measurement",
+            "device_class": "temperature",
+            "name": "{name} forward water temperature",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:thermometer-water"
+        }
+    },
+
+    "return_c": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "state_class": "measurement",
+            "device_class": "temperature",
+            "name": "{name} return water temperature",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:thermometer-water"
+        }
+    },
+
+    "difference_c": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "state_class": "measurement",
+            "device_class": "temperature",
+            "name": "{name} water temperature difference forward-return",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:thermometer-chevron-down"
+        }
+    },
+
+    "status_OK": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "problem",
+            "name": "{name} status OK",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'OK' in value_json.status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+
+    "meter_timestamp": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "state_class": "measurement",
+            "name": "{name} meter timestamp",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:timeline-clock"
+        }
+    },
+
+    "timestamp": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "state_class": "measurement",
+            "name": "{name} timestamp",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:clock"
+        }
+    },
+
+    "rssi_dbm": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "Engelmann",
+                "model": "{driver}",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "entity_category": "diagnostic",
+            "device_class": "signal_strength",
+            "state_class": "measurement",
+            "name": "{name} rssi",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "dbm",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:signal"
+        }
+    }
+}

--- a/src/driver_sensostar.cc
+++ b/src/driver_sensostar.cc
@@ -158,9 +158,15 @@ namespace
                         0xff,
                         "OK",
                         {
-                            /* What are the bits? If a bit is known then add for example:
-                               { 0x01, "OVERHEAT" }
-                            */
+                            // based on information published here: https://www.engelmann.de/wp-content/uploads/2022/10/1080621004_2022-10-12_BA_S3_ES_Comm_en.pdf
+                            { 0x01 , "ERROR_TEMP_SENSOR_1_CABLE_BREAK" },
+                            { 0x02 , "ERROR_TEMP_SENSOR_1_SHORT_CIRCUIT" },
+                            { 0x04 , "ERROR_TEMP_SENSOR_2_CABLE_BREAK" },
+                            { 0x08 , "ERROR_TEMP_SENSOR_2_SHORT_CIRCUIT" },
+                            { 0x10 , "ERROR_FLOW_MEASUREMENT_SYSTEM_ERROR" },
+                            { 0x20 , "ERROR_ELECTRONICS_DEFECT" },
+                            { 0x40 , "OK_INSTRUMENT_RESET" },
+                            { 0x80 , "OK_BATTERY_LOW" },
                         }
                     },
                 },
@@ -172,4 +178,4 @@ namespace
 // Comment:
 // telegram=|68B3B36808007257004820c51400046c100000047839803801040600000000041300000000042B00000000142B00000000043B00000000143B00000000025B1400025f15000261daff02235c00046d2c2ddc24440600000000441300000000426c000001fd171003fd0c05000084200600000000c420060000000084300600000000c430060000000084401300000000c44013000000008480401300000000c48040130000000084c0401300000000c4c0401300000000a216|
 // {"media":"heat","meter":"sensostar","name":"Heat","id":"20480057","meter_timestamp":"2022-04-28 13:44","total_kwh":0,"power_kw":0,"power_max_kw":0,"flow_water_m3h":0,"flow_water_max_m3h":0,"forward_c":20,"return_c":21,"difference_c":-0.38,"total_water_m3":0,"current_status":"ERROR_FLAGS_10","timestamp":"1111-11-11T11:11:11Z"}
-// |Heat;20480057;0.000000;0.000000;ERROR_FLAGS_10;1111-11-11 11:11.11
+// |Heat;20480057;0.000000;0.000000;ERROR_FLOW_MEASUREMENT_SYSTEM_ERROR;1111-11-11 11:11.11


### PR DESCRIPTION
- Added the required file to support MQTT discovery for sensostar meters (first commit).
- In the second commit, I extended the statuses supported by the sensostar driver based on the vendor spec + added them to MQTT discovery. Note that I was not able to test/build this new source, so I hope this is ok.