### PR TITLE
Parse history for Lorenz water meters

### DIFF
--- a/simulations/simulation_t1.txt
+++ b/simulations/simulation_t1.txt
@@ -193,8 +193,8 @@ telegram=|4644B4097172737405077AA5000610_1115F78184AB0F1D1E200000005904103103208
 # Test waterstarm
 
 telegram=|3944FA122162092002067A3600202567C94D48D00DC47B11213E23383DB51968A705AAFA60C60E263D50CD259D7C9A03FD0C08000002FD0B0011|
-{"media":"warm water","meter":"waterstarm","name":"Woter","id":"20096221","meter_timestamp":"2020-07-30 10:40","total_m3":0.106,"total_backwards_m3":0,"current_status":"OK","meter_version":"000008","parameter_set":"1100","timestamp":"1111-11-11T11:11:11Z"}
-|Woter;20096221;0.106000;0.000000;OK;1111-11-11 11:11.11
+{"media":"warm water","meter":"waterstarm","name":"Woter","id":"20096221","meter_timestamp":"2020-07-30 10:40","total_m3":0.106,"total_backwards_m3":0,"current_status":"OK","set_date":null,"consumption_at_set_date_m3":null,"meter_version":"000008","parameter_set":"1100","device_date_time":"2020-07-30 10:40","consumption_at_history_1_m3":0,"history_1_date":"","consumption_at_history_2_m3":0,"history_2_date":"","consumption_at_history_3_m3":0,"history_3_date":"","consumption_at_history_4_m3":0,"history_4_date":"","consumption_at_history_5_m3":0,"history_5_date":"","consumption_at_history_6_m3":0,"history_6_date":"","consumption_at_history_7_m3":0,"history_7_date":"","consumption_at_history_8_m3":0,"history_8_date":"","consumption_at_history_9_m3":0,"history_9_date":"","consumption_at_history_10_m3":0,"history_10_date":"","consumption_at_history_11_m3":0,"history_11_date":"","consumption_at_history_12_m3":0,"history_12_date":"","consumption_at_history_13_m3":0,"history_13_date":"","consumption_at_history_14_m3":0,"history_14_date":"","consumption_at_history_15_m3":0,"history_15_date":"","timestamp":"1111-11-11T11:11:11Z"}
+|Woter;20096221;0.106;null;null;OK;1111-11-11 11:11.11
 
 # Test topaseskr water meter
 

--- a/src/driver_waterstarm.cc
+++ b/src/driver_waterstarm.cc
@@ -22,18 +22,31 @@ namespace
     struct Driver : public virtual MeterCommonImplementation
     {
         Driver(MeterInfo &mi, DriverInfo &di);
+
+        static int const HISTORY_MONTHS = 15;
+
+        double consumption_at_history_date_m3_[HISTORY_MONTHS];
+        string history_date_[HISTORY_MONTHS];
+
+    private:
+        void processContent(Telegram *t);
+
+        string device_date_time_;
+        struct tm device_datetime_;
     };
 
     static bool ok = registerDriver([](DriverInfo&di)
     {
         di.setName("waterstarm");
+        di.setDefaultFields("name,id,total_m3,set_date,consumption_at_set_date_m3,current_status,timestamp");
         di.setMeterType(MeterType::WaterMeter);
         di.addLinkMode(LinkMode::T1);
         di.addLinkMode(LinkMode::C1);
-        di.addDetection(MANUFACTURER_DWZ,  0x06,  0x02);
+        di.addDetection(MANUFACTURER_DWZ, 0x06, 0x00);      // warm water
+        di.addDetection(MANUFACTURER_DWZ,  0x06,  0x02);    // warm water
         di.addDetection(MANUFACTURER_DWZ,  0x07,  0x02);
         di.addDetection(MANUFACTURER_EFE,  0x07,  0x03);
-        di.addDetection(MANUFACTURER_DWZ,  0x07,  0x00);
+        di.addDetection(MANUFACTURER_DWZ,  0x07,  0x00);    // water meter
 
         di.setConstructor([](MeterInfo& mi, DriverInfo& di){ return shared_ptr<Meter>(new Driver(mi, di)); });
     });
@@ -101,6 +114,29 @@ namespace
             });
 
         addStringFieldWithExtractor(
+            "set_date",
+            "The most recent billing period date.",
+            PrintProperty::JSON | PrintProperty::FIELD,
+            FieldMatcher::build()
+            .set(MeasurementType::Instantaneous)
+            .set(VIFRange::Date)
+            .set(StorageNr(1))
+            );
+
+        addNumericFieldWithExtractor(
+            "consumption_at_set_date",
+            "The total water consumption at the most recent billing period date.",
+            PrintProperty::JSON | PrintProperty::FIELD,
+            Quantity::Volume,
+            VifScaling::Auto,
+            FieldMatcher::build()
+            .set(MeasurementType::Instantaneous)
+            .set(VIFRange::Volume)
+            .set(StorageNr(1))
+            );
+
+
+        addStringFieldWithExtractor(
             "meter_version",
             "Meter model/version.",
             PrintProperty::JSON | PrintProperty::OPTIONAL,
@@ -129,25 +165,107 @@ namespace
             .set(VIFRange::Voltage)
             );
 
+        addPrint("device_date_time", Quantity::Text,
+                [&](){ return device_date_time_; },
+                "Device date time.",
+                PrintProperty::JSON);
+
+        for (int i=1; i<=HISTORY_MONTHS; ++i)
+        {
+            string msg, info;
+            strprintf(msg, "consumption_at_history_%d", i);
+            strprintf(info, "The total water consumption at the history date %d.", i);
+            addNumericFieldWithExtractor(
+                msg,
+                Quantity::Volume,
+                NoDifVifKey,
+                VifScaling::Auto,
+                MeasurementType::Instantaneous,
+                VIFRange::Volume,
+                StorageNr(i+1),
+                TariffNr(0),
+                IndexNr(1),
+                PrintProperty::JSON,
+                info,
+                SET_FUNC(consumption_at_history_date_m3_[i-1], Unit::M3),
+                GET_FUNC(consumption_at_history_date_m3_[i-1], Unit::M3));
+        }
+
+        for (int i=1; i<=HISTORY_MONTHS; ++i)
+        {
+            // string key = tostrprintf("consumption_at_history_%d", i);
+            // string epl = tostrprintf("The total water consumption at the history date %d.", i);
+
+            // addPrint(key, Quantity::Volume,
+            //     [this,i](Unit u){ assertQuantity(u, Quantity::Volume); return convert(consumption_at_history_date_m3_[i-1], Unit::M3, u); },
+            //     epl,
+            //     PrintProperty::JSON);
+            string key = tostrprintf("history_%d_date", i);
+            string epl = tostrprintf("The history date %d.", i);
+
+            addPrint(key, Quantity::Text,
+                    [this,i](){ return history_date_[i-1]; },
+                    epl,
+                    PrintProperty::JSON);
+        }
     }
+
+    void Driver::processContent(Telegram *t)
+    {
+        int offset;
+        string key;
+
+        if (findKey(MeasurementType::Instantaneous, VIFRange::DateTime, 0, 0, &key, &t->dv_entries)) {
+            extractDVdate(&t->dv_entries, key, &offset, &device_datetime_);
+            device_date_time_ = strdatetime(&device_datetime_);
+            t->addMoreExplanation(offset, " device datetime (%s)", device_date_time_.c_str());
+        }
+
+        struct tm date_start_of_history = device_datetime_; // history starts with the last month before device date
+        date_start_of_history.tm_mday = 1;
+
+        // 15 months of historical data, starting in storage 2
+        for (int i=0; i<HISTORY_MONTHS; ++i)
+        {
+            // if(findKey(MeasurementType::Instantaneous, VIFRange::Volume, i+2, 0, &key, &t->dv_entries)) {
+            //     extractDVdouble(&t->dv_entries, key, &offset, &consumption_at_history_date_m3_[i]);
+            //     t->addMoreExplanation(offset, " consumption at history %d (%f m3)", i+1, consumption_at_history_date_m3_[i]);
+                struct tm d = date_start_of_history;
+                addMonths(&d, -i);
+                history_date_[i] = strdate(&d);
+            // }
+        }
+    }    
 }
 
 // Test: Woter waterstarm 20096221 BEDB81B52C29B5C143388CBB0D15A051
 // telegram=|3944FA122162092002067A3600202567C94D48D00DC47B11213E23383DB51968A705AAFA60C60E263D50CD259D7C9A03FD0C08000002FD0B0011|
-// {"media":"warm water","meter":"waterstarm","name":"Woter","id":"20096221","meter_timestamp":"2020-07-30 10:40","total_m3":0.106,"total_backwards_m3":0,"current_status":"OK","meter_version":"000008","parameter_set":"1100","timestamp":"1111-11-11T11:11:11Z"}
-// |Woter;20096221;0.106000;0.000000;OK;1111-11-11 11:11.11
+// {"media":"warm water","meter":"waterstarm","name":"Woter","id":"20096221","meter_timestamp":"2020-07-30 10:40","total_m3":0.106,"total_backwards_m3":0,"current_status":"OK","set_date":null,"consumption_at_set_date_m3":null,"meter_version":"000008","parameter_set":"1100","device_date_time":"2020-07-30 10:40","consumption_at_history_1_m3":0,"history_1_date":"","consumption_at_history_2_m3":0,"history_2_date":"","consumption_at_history_3_m3":0,"history_3_date":"","consumption_at_history_4_m3":0,"history_4_date":"","consumption_at_history_5_m3":0,"history_5_date":"","consumption_at_history_6_m3":0,"history_6_date":"","consumption_at_history_7_m3":0,"history_7_date":"","consumption_at_history_8_m3":0,"history_8_date":"","consumption_at_history_9_m3":0,"history_9_date":"","consumption_at_history_10_m3":0,"history_10_date":"","consumption_at_history_11_m3":0,"history_11_date":"","consumption_at_history_12_m3":0,"history_12_date":"","consumption_at_history_13_m3":0,"history_13_date":"","consumption_at_history_14_m3":0,"history_14_date":"","consumption_at_history_15_m3":0,"history_15_date":"","timestamp":"1111-11-11T11:11:11Z"}
+// |Woter;20096221;0.106;null;null;OK;1111-11-11 11:11.11
 
 // telegram=|3944FA122162092002067A3604202567C94D48D00DC47B11213E23383DB51968A705AAFA60C60E263D50CD259D7C9A03FD0C08000002FD0B0011|
-// {"media":"warm water","meter":"waterstarm","name":"Woter","id":"20096221","meter_timestamp":"2020-07-30 10:40","total_m3":0.106,"total_backwards_m3":0,"current_status":"POWER_LOW","meter_version":"000008","parameter_set":"1100","timestamp":"1111-11-11T11:11:11Z"}
-// |Woter;20096221;0.106000;0.000000;POWER_LOW;1111-11-11 11:11.11
+// {"media":"warm water","meter":"waterstarm","name":"Woter","id":"20096221","meter_timestamp":"2020-07-30 10:40","total_m3":0.106,"total_backwards_m3":0,"current_status":"POWER_LOW","set_date":null,"consumption_at_set_date_m3":null,"meter_version":"000008","parameter_set":"1100","device_date_time":"2020-07-30 10:40","consumption_at_history_1_m3":0,"history_1_date":"","consumption_at_history_2_m3":0,"history_2_date":"","consumption_at_history_3_m3":0,"history_3_date":"","consumption_at_history_4_m3":0,"history_4_date":"","consumption_at_history_5_m3":0,"history_5_date":"","consumption_at_history_6_m3":0,"history_6_date":"","consumption_at_history_7_m3":0,"history_7_date":"","consumption_at_history_8_m3":0,"history_8_date":"","consumption_at_history_9_m3":0,"history_9_date":"","consumption_at_history_10_m3":0,"history_10_date":"","consumption_at_history_11_m3":0,"history_11_date":"","consumption_at_history_12_m3":0,"history_12_date":"","consumption_at_history_13_m3":0,"history_13_date":"","consumption_at_history_14_m3":0,"history_14_date":"","consumption_at_history_15_m3":0,"history_15_date":"","timestamp":"1111-11-11T11:11:11Z"}
+// |Woter;20096221;0.106;null;null;POWER_LOW;1111-11-11 11:11.11
 
 // Test: Water waterstarm 22996221 NOKEY
 // telegram=|3944FA122162992202067A360420252F2F_046D282A9E2704136A00000002FD17400004933C000000002F2F2F2F2F2F03FD0C08000002FD0B0011|
-// {"media":"warm water","meter":"waterstarm","name":"Water","id":"22996221","meter_timestamp":"2020-07-30 10:40","total_m3":0.106,"total_backwards_m3":0,"current_status":"LEAKAGE_OR_NO_USAGE POWER_LOW","meter_version":"000008","parameter_set":"1100","timestamp":"1111-11-11T11:11:11Z"}
-// |Water;22996221;0.106000;0.000000;LEAKAGE_OR_NO_USAGE POWER_LOW;1111-11-11 11:11.11
+// {"media":"warm water","meter":"waterstarm","name":"Water","id":"22996221","meter_timestamp":"2020-07-30 10:40","total_m3":0.106,"total_backwards_m3":0,"current_status":"LEAKAGE_OR_NO_USAGE POWER_LOW","set_date":null,"consumption_at_set_date_m3":null,"meter_version":"000008","parameter_set":"1100","device_date_time":"2020-07-30 10:40","consumption_at_history_1_m3":0,"history_1_date":"","consumption_at_history_2_m3":0,"history_2_date":"","consumption_at_history_3_m3":0,"history_3_date":"","consumption_at_history_4_m3":0,"history_4_date":"","consumption_at_history_5_m3":0,"history_5_date":"","consumption_at_history_6_m3":0,"history_6_date":"","consumption_at_history_7_m3":0,"history_7_date":"","consumption_at_history_8_m3":0,"history_8_date":"","consumption_at_history_9_m3":0,"history_9_date":"","consumption_at_history_10_m3":0,"history_10_date":"","consumption_at_history_11_m3":0,"history_11_date":"","consumption_at_history_12_m3":0,"history_12_date":"","consumption_at_history_13_m3":0,"history_13_date":"","consumption_at_history_14_m3":0,"history_14_date":"","consumption_at_history_15_m3":0,"history_15_date":"","timestamp":"1111-11-11T11:11:11Z"}
+// |Water;22996221;0.106;null;null;LEAKAGE_OR_NO_USAGE POWER_LOW;1111-11-11 11:11.11
 
 
 // Test: Water waterstarm 11559999 NOKEY
 // telegram=|2E44FA129999551100077A070020252F2F_046D0F28C22404139540000002FD17000001FD481D2F2F2F2F2F2F2F2F2F|
-// {"media":"water","meter":"waterstarm","name":"Water","id":"11559999","meter_timestamp":"2022-04-02 08:15","total_m3":16.533,"total_backwards_m3":null,"current_status":"OK","battery_v":2.9,"timestamp":"1111-11-11T11:11:11Z"}
-// |Water;11559999;16.533000;nan;OK;1111-11-11 11:11.11
+// {"media":"water","meter":"waterstarm","name":"Water","id":"11559999","meter_timestamp":"2022-04-02 08:15","total_m3":16.533,"total_backwards_m3":null,"current_status":"OK","set_date":null,"consumption_at_set_date_m3":null,"battery_v":2.9,"device_date_time":"2022-04-02 08:15","consumption_at_history_1_m3":0,"history_1_date":"","consumption_at_history_2_m3":0,"history_2_date":"","consumption_at_history_3_m3":0,"history_3_date":"","consumption_at_history_4_m3":0,"history_4_date":"","consumption_at_history_5_m3":0,"history_5_date":"","consumption_at_history_6_m3":0,"history_6_date":"","consumption_at_history_7_m3":0,"history_7_date":"","consumption_at_history_8_m3":0,"history_8_date":"","consumption_at_history_9_m3":0,"history_9_date":"","consumption_at_history_10_m3":0,"history_10_date":"","consumption_at_history_11_m3":0,"history_11_date":"","consumption_at_history_12_m3":0,"history_12_date":"","consumption_at_history_13_m3":0,"history_13_date":"","consumption_at_history_14_m3":0,"history_14_date":"","consumption_at_history_15_m3":0,"history_15_date":"","timestamp":"1111-11-11T11:11:11Z"}
+// |Water;11559999;16.533;null;null;OK;1111-11-11 11:11.11
+
+
+// Test: WarmLorenz waterstarm 20050666 NOKEY
+// telegram=|9644FA126606052000067A1E000020_046D3B2ED729041340D8000002FD17000001FD481D426CBF2C4413026C000084011348D20000C40113F3CB0000840213DCC40000C40213B8B60000840313849B0000C403138B8C0000840413E3800000C4041337770000840513026C0000C40513D65F00008406134F560000C40613604700008407139D370000C407137F3300008408135B2C0000|
+// {"media":"warm water","meter":"waterstarm","name":"WarmLorenz","id":"20050666","meter_timestamp":"2022-09-23 14:59","total_m3":55.36,"total_backwards_m3":null,"current_status":"OK","set_date":"2021-12-31","consumption_at_set_date_m3":27.65,"battery_v":2.9,"device_date_time":"2022-09-23 14:59","consumption_at_history_1_m3":53.832,"history_1_date":"2022-09-01","consumption_at_history_2_m3":52.211,"history_2_date":"2022-08-01","consumption_at_history_3_m3":50.396,"history_3_date":"2022-07-01","consumption_at_history_4_m3":46.776,"history_4_date":"2022-06-01","consumption_at_history_5_m3":39.812,"history_5_date":"2022-05-01","consumption_at_history_6_m3":35.979,"history_6_date":"2022-04-01","consumption_at_history_7_m3":32.995,"history_7_date":"2022-03-01","consumption_at_history_8_m3":30.519,"history_8_date":"2022-02-01","consumption_at_history_9_m3":27.65,"history_9_date":"2022-01-01","consumption_at_history_10_m3":24.534,"history_10_date":"2021-12-01","consumption_at_history_11_m3":22.095,"history_11_date":"2021-11-01","consumption_at_history_12_m3":18.272,"history_12_date":"2021-10-01","consumption_at_history_13_m3":14.237,"history_13_date":"2021-09-01","consumption_at_history_14_m3":13.183,"history_14_date":"2021-08-01","consumption_at_history_15_m3":11.355,"history_15_date":"2021-07-01","timestamp":"1111-11-11T11:11:11Z"}
+// |WarmLorenz;20050666;55.36;2021-12-31;27.65;OK;1111-11-11 11:11.11
+
+
+// Test: ColdLorenz waterstarm 20050665 NOKEY
+// telegram=|9644FA126051062000077A78000020_046D392DD7290413901A000002FD17000001FD481D426CBF2C4413D312000084011399190000C40113841800008402130C180000C40213EC16000084031395150000C40313E3140000840413BD130000C404134C130000840513D3120000C4051322120000840613AF110000C4061397100000840713D00F0000C40713890E0000840813980C0000|
+// {"media":"water","meter":"waterstarm","name":"ColdLorenz","id":"20065160","meter_timestamp":"2022-09-23 13:57","total_m3":6.8,"total_backwards_m3":null,"current_status":"OK","set_date":"2021-12-31","consumption_at_set_date_m3":4.819,"battery_v":2.9,"device_date_time":"2022-09-23 13:57","consumption_at_history_1_m3":6.553,"history_1_date":"2022-09-01","consumption_at_history_2_m3":6.276,"history_2_date":"2022-08-01","consumption_at_history_3_m3":6.156,"history_3_date":"2022-07-01","consumption_at_history_4_m3":5.868,"history_4_date":"2022-06-01","consumption_at_history_5_m3":5.525,"history_5_date":"2022-05-01","consumption_at_history_6_m3":5.347,"history_6_date":"2022-04-01","consumption_at_history_7_m3":5.053,"history_7_date":"2022-03-01","consumption_at_history_8_m3":4.94,"history_8_date":"2022-02-01","consumption_at_history_9_m3":4.819,"history_9_date":"2022-01-01","consumption_at_history_10_m3":4.642,"history_10_date":"2021-12-01","consumption_at_history_11_m3":4.527,"history_11_date":"2021-11-01","consumption_at_history_12_m3":4.247,"history_12_date":"2021-10-01","consumption_at_history_13_m3":4.048,"history_13_date":"2021-09-01","consumption_at_history_14_m3":3.721,"history_14_date":"2021-08-01","consumption_at_history_15_m3":3.224,"history_15_date":"2021-07-01","timestamp":"1111-11-11T11:11:11Z"}
+// |ColdLorenz;20050665;6.8;2021-12-31;4.819;OK;1111-11-11 11:11.11


### PR DESCRIPTION
Hi,

driver_waterstarm.cc parses Lorenz water meters already. There was one id missing, but then it worked for the ones I have tried.

However, the current driver only parses some very basic data, but the manufacturer told me that the water meters I have have been configured for the long message format and indeed there is more information that driver_waterstarm.cc did not yet parse. I have added that code, which parses the consumption history for the last 15 months from the telegram.

But now the tests fail as the new code doesn't work correctly anymore for the short type telegrams that were included in the tests already. I don't even know what is supposed to be returned in the case of a short telegram. Should it be "0.0" m³ consumption for the historic dates? This is not correct, since we actually just don't know the consumption, which is different from "0.0" m³. But it seems that I have to add which fields are there before actually parsing the telegram, so at a point where I don't know whether it is a short or long telegram.

In addition, addNumericFieldWithExtractor seems not to handle situations well when the field does not exist or I have a bug in the code ... if it is a short message, there is always one historic value that contains garbage from memory, i.e. very high consumptions. I think I can avoid this if I just call "addPrint" in the constructor and fill the actual values in the processContent method. I have the code in my commit already, but commented out.

So, at this point I would be glad to receive some help with the question:
**How can I deal with fields that may or may not be present in the telegram and I only know whether they are present in the telegram after parsing the message?**