### PR TITLE
Update input unit for total energy for Sharky 774

### DIFF
--- a/src/driver_sharky774.cc
+++ b/src/driver_sharky774.cc
@@ -59,7 +59,7 @@ MeterSharky774::MeterSharky774(MeterInfo &mi, DriverInfo &di) :  MeterCommonImpl
         PrintProperty::JSON | PrintProperty::FIELD | PrintProperty::IMPORTANT,
         "The total energy consumption recorded by this meter.",
         SET_FUNC(total_energy_consumption_kwh_, Unit::KWH),
-        GET_FUNC(total_energy_consumption_kwh_, Unit::KWH));
+        GET_FUNC(total_energy_consumption_kwh_, Unit::MJ));
 
     addNumericFieldWithExtractor(
         "total_volume",


### PR DESCRIPTION
The meter is sending the total energy in MJ.

I've installed wmbusmeters on my other device and noticed that the total energy consumption value was 3600 times greater than the device was showing. Something went wrong during the refactoring as the unit was set correctly when the driver was added to the app: https://github.com/weetmuts/wmbusmeters/pull/425 (driver_sharky774.cc line 96)