### PR TITLE
Add support for a different version of flowiq2200

### DIFF
--- a/src/driver_flowiq2200.cc
+++ b/src/driver_flowiq2200.cc
@@ -32,6 +32,7 @@ namespace
         di.addLinkMode(LinkMode::C1);
         // FlowIQ2200
         di.addDetection(MANUFACTURER_KAW,  0x16,  0x3a);
+	di.addDetection(MANUFACTURER_KAW,  0x16,  0x3c);
         // FlowIQ3100
         di.addDetection(MANUFACTURER_KAM,  0x16,  0x1d);
 


### PR DESCRIPTION
I apparently have a different version of the Kamstrup flowIQ 2200 (KWM2231). With this little modification, it works flawlessly.