### PR TITLE
Change tsd2 HomeAssistant device class to 'smoke'

### DIFF
--- a/ha-addon/mqtt_discovery/tsd2.json
+++ b/ha-addon/mqtt_discovery/tsd2.json
@@ -10,7 +10,7 @@
                 "sw_version": "{id}"
             },
             "enabled_by_default": true,
-            "device_class": "problem",
+            "device_class": "smoke",
             "name": "{name} status smoke",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",


### PR DESCRIPTION
HomeAssistant provides support for the 'smoke' device-class which lets the sensors appear correctly in the overview.

See https://www.home-assistant.io/integrations/binary_sensor/#device-class