### PR TITLE
Add device class water to qwater autodiscovery

### DIFF
--- a/ha-addon/mqtt_discovery/qwater.json
+++ b/ha-addon/mqtt_discovery/qwater.json
@@ -11,6 +11,7 @@
                 "name": "{name}",
                 "sw_version": "{id}"
             },
+            "device_class": "water",
             "enabled_by_default": true,
             "json_attributes_topic": "wmbusmeters/{name}",
             "state_class": "total",


### PR DESCRIPTION
This enables the Sensor to be used as part of the Home Assistant Energy dashboard.