### PR TITLE
Calculate correct history dates for Lorenz water meters

### DIFF
--- a/src/driver_waterstarm.cc
+++ b/src/driver_waterstarm.cc
@@ -42,10 +42,12 @@ namespace
 
     Driver::Driver(MeterInfo &mi, DriverInfo &di) : MeterCommonImplementation(mi, di)
     {
-        addStringFieldWithExtractor(
+        addNumericFieldWithExtractor(
             "meter_timestamp",
             "Device date time.",
             PrintProperty::JSON | PrintProperty::OPTIONAL,
+            Quantity::PointInTime,
+            VifScaling::Auto,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::DateTime)
@@ -173,7 +175,7 @@ namespace
             "The historic date #.",
             PrintProperty::JSON | PrintProperty::OPTIONAL,
             Quantity::PointInTime,
-            "meter_timestamp - ((storage_counter-1counter) * 1 month)",
+            "meter_timestamp_date - ((storage_counter-1counter) * 1 month)",
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::Volume)

--- a/src/driver_waterstarm.cc
+++ b/src/driver_waterstarm.cc
@@ -132,20 +132,8 @@ namespace
             );
 
         addNumericFieldWithExtractor(
-            "consumption_at_history_{storage_counter}",
-            "The total water consumption at the historic date.",
-            PrintProperty::JSON | PrintProperty::OPTIONAL,
-            Quantity::Volume,
-            VifScaling::Auto,
-            FieldMatcher::build()
-            .set(MeasurementType::Instantaneous)
-            .set(VIFRange::Volume)
-            .set(StorageNr(1),StorageNr(16))
-            );
-
-        addNumericFieldWithExtractor(
-            "history_reference",
-            "Reference date for history.",
+            "set_date",
+            "The most recent billing period date.",
             PrintProperty::JSON | PrintProperty::OPTIONAL,
             Quantity::PointInTime,
             VifScaling::Auto,
@@ -156,16 +144,40 @@ namespace
             Unit::DateLT
             );
 
-        addNumericFieldWithCalculatorAndMatcher(
-            "history_{storage_counter}",
-            "The historic date #.",
+        addNumericFieldWithExtractor(
+            "consumption_at_set_date",
+            "The total water consumption at the most recent billing period date.",
             PrintProperty::JSON | PrintProperty::OPTIONAL,
-            Quantity::PointInTime,
-            "history_reference_date - ((storage_counter-1counter) * 1 month)",
+            Quantity::Volume,
+            VifScaling::Auto,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::Volume)
-            .set(StorageNr(1),StorageNr(16)),
+            .set(StorageNr(1))
+            );            
+
+        addNumericFieldWithExtractor(
+            "consumption_at_history_{storage_counter - 1 counter}",
+            "The total water consumption at the historic date.",
+            PrintProperty::JSON | PrintProperty::OPTIONAL,
+            Quantity::Volume,
+            VifScaling::Auto,
+            FieldMatcher::build()
+            .set(MeasurementType::Instantaneous)
+            .set(VIFRange::Volume)
+            .set(StorageNr(2),StorageNr(16))
+            );
+
+        addNumericFieldWithCalculatorAndMatcher(
+            "history_{storage_counter - 1 counter}",
+            "The historic date #.",
+            PrintProperty::JSON | PrintProperty::OPTIONAL,
+            Quantity::PointInTime,
+            "meter_timestamp - ((storage_counter-1counter) * 1 month)",
+            FieldMatcher::build()
+            .set(MeasurementType::Instantaneous)
+            .set(VIFRange::Volume)
+            .set(StorageNr(2),StorageNr(16)),
             Unit::DateLT
             );
     }


### PR DESCRIPTION
This is an extension to the calculations of driver_waterstarm, where @weetmuts added parsing historic consumption data after I triggered this with PR #687 . 

The dates were not interpreted correctly, though, and this patch improves this, although the dates are still not completely correct.

My water meters report three types of consumption:
- current consumption
- consumption at the last billing period (December 31 of last year) in StorageNr 1
- consumption at the end of the last 15 months in StorageNr 2-16

This patch corrects the how the second consumption value is interpreted and ... more correctly calculates the dates for the last 15 months. It isn't the last day of the month that is returned for these 15 values, though, but just one in that month (on the same day as the device reading).

This is because I found that the formula engine seems to be lacking the capabilities to calculate the last day of the month, but before I started improving it, I wanted to align with the maintainer. My current formula is this:

```
meter_timestamp_date - ((storage_counter-1counter) * 1 month)
```

I thought about adding a function DAY_OF_MONTH that returns the days of the month in a datetime and then using this formula:

```
meter_timestamp_date - ((storage_counter-2counter) * 1 month) - DAY_OF_MONTH(meter_timestamp_date)
```

(note that I increased the counter by one to get to the next month)

I am willing to add this to formula.cc myself if the maintainer agrees with the approach or has another one that I am capable of implementing, but I might need some time. If somebody else does it, even better ;-).

In any case, I think this PR can be merged already, as it is in any regard better than what is currently in master, if no bug sneaked in.

I will add another telegram from the same meter to validate the calculation (need to start my taken-apart wmbusmeters first to receive it), but it is already visible in the existing test telegram (https://wmbusmeters.org/analyze/9644FA126606052000067A1E000020046D3B2ED729041340D8000002FD17000001FD481D426CBF2C4413026C000084011348D20000C40113F3CB0000840213DCC40000C40213B8B60000840313849B0000C403138B8C0000840413E3800000C4041337770000840513026C0000C40513D65F00008406134F560000C40613604700008407139D370000C407137F3300008408135B2C0000); note that Storagenr 2 and 10 contain the same amount, because 2 is the consumption at set-date and 10 is the end-of-month ~9 months before meter_datetime. total_m3 is slightly more than what is in storagenr 3, which is the latest historic end-of-month consumption.