### PR TITLE
Add ports to forward for netcat to ha-addon. User can use rtlwmbus:CMD as device

### DIFF
--- a/ha-addon/config.json
+++ b/ha-addon/config.json
@@ -11,6 +11,14 @@
     "devices": ["/dev/ttyUSB0", "/dev/ttyAMA0"],
     "usb": true,
     "uart": true,
+    "ports": {
+      "9011/udp": null,
+      "9022/tcp": null
+    },
+    "ports_description": {
+      "9011/udp": "Netcat udp-listen port",
+      "9022/tcp": "Netcat tcp-listen port"
+    },
     "services": [
       "mqtt:need"
     ],


### PR DESCRIPTION
Added ports to ha-addon (UDP and TCP) to allow use of:
`device=rtlwmbus:CMD(/usr/bin/nc -lku 9011)`
or
`device=rtlwmbus:CMD(/usr/bin/nc -lk 9022)`