### PR TITLE
Infer current year in fhkvdataiii

### DIFF
--- a/src/driver_fhkvdataiii.cc
+++ b/src/driver_fhkvdataiii.cc
@@ -98,10 +98,10 @@ namespace
 
         int day_prev = (date_prev >> 0) & 0x1F;
         int month_prev = (date_prev >> 5) & 0x0F;
-        int year_prev = (date_prev >> 9) & 0x3F;
+        int year_prev = 2000 + ((date_prev >> 9) & 0x3F);
 
         string previous_date =
-            std::to_string((year_prev + 2000)) + "-" +
+            std::to_string(year_prev) + "-" +
             leadingZeroString(month_prev) + "-" +
             leadingZeroString(day_prev) + "T02:00:00Z";
 
@@ -133,17 +133,17 @@ namespace
         uchar date_curr_hi = content[6];
         int date_curr = (256.0*date_curr_hi+date_curr_lo);
 
-        time_t now = time(0);
-        tm *ltm = localtime(&now);
-        int year_curr = 1900 + ltm->tm_year;
-
         int day_curr = (date_curr >> 4) & 0x1F;
         if (day_curr <= 0) day_curr = 1;
         int month_curr = (date_curr >> 9) & 0x0F;
         if (month_curr <= 0) month_curr = 12;
+        int year_curr = year_prev;
+        if (month_curr < month_prev || (month_curr == month_prev && day_curr <= day_prev)) {
+            year_curr++;
+        }
 
         string current_date =
-            to_string(year_curr) + "-" +
+            std::to_string(year_curr) + "-" +
             leadingZeroString(month_curr) + "-" +
             leadingZeroString(day_curr) + "T02:00:00Z";
 
@@ -217,13 +217,11 @@ namespace
 }
 
 // Test: Room fhkvdataiii 11776622 NOKEY
-// Comment: There is a problem in the decoding here, the data stored inside the telegram does not seem to properly encode/decode the year.... We should not report a current_date with a full year, if the year is actually not part of the telegram.
 // telegram=|31446850226677116980A0119F27020480048300C408F709143C003D341A2B0B2A0707000000000000062D114457563D71A1850000|
-// {"media":"heat cost allocator","meter":"fhkvdataiii","name":"Room","id":"11776622","current_hca":131,"current_date":"2023-02-08T02:00:00Z","previous_hca":1026,"previous_date":"2019-12-31T02:00:00Z","temp_room_c":22.44,"temp_radiator_c":25.51,"timestamp":"1111-11-11T11:11:11Z"}
-// |Room;11776622;131;2023-02-08T02:00:00Z;1026;2019-12-31T02:00:00Z;22.44;25.51;1111-11-11 11:11.11
+// {"media":"heat cost allocator","meter":"fhkvdataiii","name":"Room","id":"11776622","current_hca":131,"current_date":"2020-02-08T02:00:00Z","previous_hca":1026,"previous_date":"2019-12-31T02:00:00Z","temp_room_c":22.44,"temp_radiator_c":25.51,"timestamp":"1111-11-11T11:11:11Z"}
+// |Room;11776622;131;2020-02-08T02:00:00Z;1026;2019-12-31T02:00:00Z;22.44;25.51;1111-11-11 11:11.11
 
 // Test: Rooom fhkvdataiii 11111234 NOKEY
-// Comment: FHKV radio 4 / EHKV vario 4 There is a problem in the decoding here, the data stored inside the telegram does not seem to properly encode/decode the year.... We should not report a current_date with a full year, if the year is actually not part of the telegram.
 // telegram=|33446850341211119480A2_0F9F292D005024040011BD08380904000000070000000000000000000000000001000000000003140E|
-// {"media":"heat cost allocator","meter":"fhkvdataiii","name":"Rooom","id":"11111234","current_hca":4,"current_date":"2023-02-05T02:00:00Z","previous_hca":45,"previous_date":"2020-12-31T02:00:00Z","temp_room_c":22.37,"temp_radiator_c":23.6,"timestamp":"1111-11-11T11:11:11Z"}
-// |Rooom;11111234;4;2023-02-05T02:00:00Z;45;2020-12-31T02:00:00Z;22.37;23.6;1111-11-11 11:11.11
+// {"media":"heat cost allocator","meter":"fhkvdataiii","name":"Rooom","id":"11111234","current_hca":4,"current_date":"2021-02-05T02:00:00Z","previous_hca":45,"previous_date":"2020-12-31T02:00:00Z","temp_room_c":22.37,"temp_radiator_c":23.6,"timestamp":"1111-11-11T11:11:11Z"}
+// |Rooom;11111234;4;2021-02-05T02:00:00Z;45;2020-12-31T02:00:00Z;22.37;23.6;1111-11-11 11:11.11


### PR DESCRIPTION
Thinking about #780 a bit more, I think we can actually infer the current year from the previous year. This might be the reason it is not transmitted in the first place.