### PR TITLE
Add Diehl IZAR RC 868 I R4 PL water meter to MQTT auto-discovery

### DIFF
--- a/ha-addon/mqtt_discovery/izar.json
+++ b/ha-addon/mqtt_discovery/izar.json
@@ -1,0 +1,148 @@
+{
+  "total_m3": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "Diehl",
+        "model": "Water meter IZAR RC 868 I R4 PL",
+        "name": "{name}",
+        "sw_version": "{id}"
+      },
+      "name": "{name} total",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:gauge",
+      "unit_of_measurement": "m³",
+      "state_class": "total_increasing",
+      "device_class": "water",
+      "enabled_by_default": true
+    }
+  },
+
+  "last_month_total_m3": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "Diehl",
+        "model": "Water meter IZAR RC 868 I R4 PL",
+        "name": "{name}",
+        "sw_version": "{id}"
+      },
+      "name": "{name} last month total",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:gauge",
+      "unit_of_measurement": "m³",
+      "state_class": "total_increasing",
+      "device_class": "water",
+      "enabled_by_default": true
+    }
+  },
+
+  "last_month_measure_date": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "Diehl",
+        "model": "Water meter IZAR RC 868 I R4 PL",
+        "name": "{name}",
+        "sw_version": "{id}"
+      },
+      "entity_category": "diagnostic",
+      "name": "{name} last month measure date",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:calendar-clock",
+      "enabled_by_default": false
+    }
+  },
+
+  "timestamp": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "Diehl",
+        "model": "Water meter IZAR RC 868 I R4 PL",
+        "name": "{name}",
+        "sw_version": "{id}"
+      },
+      "entity_category": "diagnostic",
+      "name": "{name} timestamp",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:calendar-clock",
+      "enabled_by_default": false
+    }
+  },
+
+  "rssi_dbm": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "Diehl",
+        "model": "Water meter IZAR RC 868 I R4 PL",
+        "name": "{name}",
+        "sw_version": "{id}"
+      },
+      "entity_category": "diagnostic",
+      "name": "{name} rssi",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:signal",
+      "unit_of_measurement": "dbm",
+      "device_class": "signal_strength",
+      "state_class": "measurement",
+      "enabled_by_default": false
+    }
+  },
+
+  "current_alarms": {
+      "component": "sensor",
+      "discovery_payload": {
+          "device": {
+              "identifiers": ["wmbusmeters_{id}"],
+              "manufacturer": "Water meter IZAR RC 868 I R4 PL",
+              "model": "{driver}",
+              "name": "{name}",
+              "sw_version": "{id}"
+          },
+          "name": "{name} current alarm",
+          "state_topic": "wmbusmeters/{name}",
+          "unique_id": "wmbusmeters_{id}_{attribute}",
+          "value_template": "{{ value_json.{attribute} }}",
+          "icon": "mdi:alarm-light-outline",
+          "enabled_by_default": true
+      }
+  },
+
+  "previous_alarms": {
+    "component": "sensor",
+    "discovery_payload": {
+        "device": {
+            "identifiers": ["wmbusmeters_{id}"],
+            "manufacturer": "Water meter IZAR RC 868 I R4 PL",
+            "model": "{driver}",
+            "name": "{name}",
+            "sw_version": "{id}"
+        },
+        "name": "{name} previous alarm",
+        "state_topic": "wmbusmeters/{name}",
+        "unique_id": "wmbusmeters_{id}_{attribute}",
+        "value_template": "{{ value_json.{attribute} }}",
+        "icon": "mdi:alarm-light-outline",
+        "enabled_by_default": true
+    }
+  }
+}

--- a/ha-addon/mqtt_discovery/izar.json
+++ b/ha-addon/mqtt_discovery/izar.json
@@ -113,8 +113,8 @@
       "discovery_payload": {
           "device": {
               "identifiers": ["wmbusmeters_{id}"],
-              "manufacturer": "Water meter IZAR RC 868 I R4 PL",
-              "model": "{driver}",
+              "manufacturer": "Diehl",
+              "model": "Water meter IZAR RC 868 I R4 PL",
               "name": "{name}",
               "sw_version": "{id}"
           },
@@ -132,8 +132,8 @@
     "discovery_payload": {
         "device": {
             "identifiers": ["wmbusmeters_{id}"],
-            "manufacturer": "Water meter IZAR RC 868 I R4 PL",
-            "model": "{driver}",
+            "manufacturer": "Diehl",
+            "model": "Water meter IZAR RC 868 I R4 PL",
             "name": "{name}",
             "sw_version": "{id}"
         },

--- a/ha-addon/mqtt_discovery/izar.json
+++ b/ha-addon/mqtt_discovery/izar.json
@@ -7,7 +7,7 @@
         "manufacturer": "Diehl",
         "model": "Water meter IZAR RC 868 I R4 PL",
         "name": "{name}",
-        "sw_version": "{id}"
+        "hw_version": "{id}"
       },
       "name": "{name} total",
       "unique_id": "wmbusmeters_{id}_{attribute}",
@@ -30,7 +30,7 @@
         "manufacturer": "Diehl",
         "model": "Water meter IZAR RC 868 I R4 PL",
         "name": "{name}",
-        "sw_version": "{id}"
+        "hw_version": "{id}"
       },
       "name": "{name} last month total",
       "unique_id": "wmbusmeters_{id}_{attribute}",
@@ -53,7 +53,7 @@
         "manufacturer": "Diehl",
         "model": "Water meter IZAR RC 868 I R4 PL",
         "name": "{name}",
-        "sw_version": "{id}"
+        "hw_version": "{id}"
       },
       "entity_category": "diagnostic",
       "name": "{name} last month measure date",
@@ -73,7 +73,7 @@
         "manufacturer": "Diehl",
         "model": "Water meter IZAR RC 868 I R4 PL",
         "name": "{name}",
-        "sw_version": "{id}"
+        "hw_version": "{id}"
       },
       "entity_category": "diagnostic",
       "name": "{name} timestamp",
@@ -93,7 +93,7 @@
         "manufacturer": "Diehl",
         "model": "Water meter IZAR RC 868 I R4 PL",
         "name": "{name}",
-        "sw_version": "{id}"
+        "hw_version": "{id}"
       },
       "entity_category": "diagnostic",
       "name": "{name} rssi",
@@ -116,7 +116,7 @@
               "manufacturer": "Diehl",
               "model": "Water meter IZAR RC 868 I R4 PL",
               "name": "{name}",
-              "sw_version": "{id}"
+              "hw_version": "{id}"
           },
           "name": "{name} current alarm",
           "state_topic": "wmbusmeters/{name}",
@@ -135,7 +135,7 @@
             "manufacturer": "Diehl",
             "model": "Water meter IZAR RC 868 I R4 PL",
             "name": "{name}",
-            "sw_version": "{id}"
+            "hw_version": "{id}"
         },
         "name": "{name} previous alarm",
         "state_topic": "wmbusmeters/{name}",


### PR DESCRIPTION
Hi all,

I've made an attempt to create an auto-discovery file for the relatively popular IZAR driver. Since it's my first commit every, please excuse any obvious issues or breaches of coding etiquette. 

I am awaiting some assistance with an MQTT auto-discovery error (https://github.com/weetmuts/wmbusmeters/issues/550), so the above has not been tested yet, but if someone would like to try it out, it's as simple as creating a .json file in your mqtt_discovery folder.

Thank you!