### PR TITLE
Included Techem vario 3 type 3.2.1 in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,8 @@ BFW 240 (bfw240radio)
 
 Supported heat meters:
 Heat meter Techem Compact V / Compact Ve (compact5) (non-standard protocol)
-Heat meter Techem Vario 4 (vario451) (non-standard protocol)
+Heat meter Techem vario 3 type 3.2.1 (mkradio3) (see here: https://github.com/weetmuts/wmbusmeters/issues/333)
+Heat meter Techem vario 4 (vario451) (non-standard protocol)
 Heat and Cooling meters Kamstrup Multical 302,403,602,603,803 (kamheat)
 Heat meter Apator Elf (elf)
 Heat meter Enercal F2 (enercal)


### PR DESCRIPTION
Even though https://github.com/weetmuts/wmbusmeters/issues/333 is still open (from what I see only some trivial mapping needs to be done), the meter got included into the readme, since it does already work with some workaround.