### PR TITLE
Add 0x7c0e hash to list of known meter format signatures

### DIFF
--- a/src/wmbus.cc
+++ b/src/wmbus.cc
@@ -4028,6 +4028,11 @@ bool Telegram::findFormatBytesFromKnownMeterSignatures(vector<uchar> *format_byt
         hex2bin("02FF2004134413", format_bytes);
         debug("(wmbus) using hard coded format for hash dd34\n");
     }
+    else if (format_signature == 0x7c0e)
+    {
+        hex2bin("02FF200413523B", format_bytes);
+        debug("(wmbus) using hard coded format for hash 7c0e\n");
+    }
     else
     {
         ok = false;


### PR DESCRIPTION
Adds an additional hash, format pair to the list of hardcoded formats.

```
./build/wmbusmeters --analyze=auto:12345678... 1f442d2c508248631b168d202eb1a99024efd3759b107ec1105a63b0766a5c60
Auto driver  : multical21
Best driver  : flowiq2200 08/08
Using driver : multical21 00/00
000   : 1f length (31 bytes)
001   : 44 dll-c (from meter SND_NR)
002   : 2d2c dll-mfct (KAM)
004   : 50824863 dll-id (63488250)
008   : 1b dll-version
009   : 16 dll-type (Cold water meter)
010   : 8d ell-ci-field (ELL: Extended Link Layer II (8 Byte))
011   : 20 ell-cc (slow_resp sync)
012   : 2e ell-acc
013   : b1a99024 sn (AES_CTR)
017   : 80b7 payload crc (calculated 80b7 OK)
019   : 79 tpl-ci-field (EN 13757-3 Application Layer with Compact frame (no tplh))
020   : 0e7c format signature
022   : 31a1 data crc
024 C!: 0000 ("status":"OK") ("current_status":"") ("time_dry":"") ("time_reversed":"") ("time_leaking":"") ("time_bursting":"")
026 C!: 81590B00 ("total_m3":743.809)
030 C!: 1201 ("max_flow_m3h":0.274)

{
    "media":"cold water",
    "meter":"multical21",
    "name":"",
    "id":"63488250",
    "status":"OK",
    "total_m3":743.809,
    "max_flow_m3h":0.274,
    "current_status":"",
    "time_dry":"",
    "time_reversed":"",
    "time_leaking":"",
    "time_bursting":"",
    "timestamp":"2023-02-13T15:29:31Z"
}
```

Fixes #851 