### PR TITLE
Update the link to the DOCS

### DIFF
--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Configuration format has changed since version 1.11.0-1.
 Back up Your HA Addon configuration prior to upgrade.
-Consult [DOCS.md](docs) about current configuration format.
+Consult [DOCS.md](https://github.com/weetmuts/wmbusmeters/blob/master/ha-addon/DOCS.md) about current configuration format.
 
 # Release
 


### PR DESCRIPTION
@BIBOLV 

Not sure if a direct link is how it should be done or if one can link it to a generic `docs` link, which will always follow the specific `docs` file location, as it moves. I took a stab at fixing it the simplest way for now.