### PR TITLE
[HA Addon] Make meters section optional

### DIFF
--- a/ha-addon/config.json
+++ b/ha-addon/config.json
@@ -64,11 +64,6 @@
           "logfile": "str",
           "shell": "str"
         },
-        "meters": {
-            "name": "str",
-            "driver": "str",
-            "id": "str",
-            "key": "str"
-          }
+        "meters": {}
     }
 }


### PR DESCRIPTION
Related to #859, current schema assumes only one meter is possible.

![Screenshot 2023-02-16 at 18-16-48 Home Assistant](https://user-images.githubusercontent.com/24268470/219439589-733d4a00-6ac3-4394-9fde-4b90051e2a18.png)
