### PR TITLE
Create trigger_ha_addon.yml

### DIFF
--- a/.github/workflows/trigger_ha_addon.yml
+++ b/.github/workflows/trigger_ha_addon.yml
@@ -1,0 +1,45 @@
+name: Trigger HA add-on build
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*.*.*'
+
+jobs:
+  trigger_ha_addon_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - run: git fetch --prune --unshallow
+
+      - name: Get wmbusmeters version
+        id: version
+        run: |
+          if [ -n "$(git describe --tags | grep -)" ]; then
+            GIT_VER="$(git describe --tags | cut -f1,2 -d'-')"
+            echo "id=${GIT_VER}" >> $GITHUB_OUTPUT
+          else
+            GIT_VER="$(git describe --tags)"
+            echo "id=${GIT_VER}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Trigger build for edge release
+        if: ${{ github.ref_name == 'master' }}
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.HA_PAT }}
+          repository: wmbusmeters/wmbusmeters-ha-addon
+          event-type: build_ha_edge
+          client-payload: '{"ver": "${{ steps.version.outputs.id }}"}'
+
+      - name: Trigger build for stable release
+        if: ${{ github.ref_name != 'master' }}
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.HA_PAT }}
+          repository: wmbusmeters/wmbusmeters-ha-addon
+          event-type: build_ha_stable
+          client-payload: '{"ver": "${{ steps.version.outputs.id }}"}'


### PR DESCRIPTION
Action for ha-addon container build trigger in wmbusmeters/wmbusmeters-ha-addon repo. 
This should be accepted after secrets has been configured in all related repos. 
Starting from now all ha-addon changes should go to wmbusmeters/wmbusmeters-ha-addon repo and should not be accepted here. 
After next release I will make changelog changes to inform users to switch to new repo.