### PR TITLE
Update driver_eurisii.cc

### DIFF
--- a/src/driver_eurisii.cc
+++ b/src/driver_eurisii.cc
@@ -31,6 +31,7 @@ namespace
         di.setMeterType(MeterType::HeatCostAllocationMeter);
         di.addLinkMode(LinkMode::T1);
         di.addDetection(MANUFACTURER_INE,  0x08,  0x55);
+        di.addDetection(MANUFACTURER_RAM,  0x08,  0x55);
         di.setConstructor([](MeterInfo& mi, DriverInfo& di){ return shared_ptr<Meter>(new Driver(mi, di)); });
     });
 


### PR DESCRIPTION
added (RAM) Rossweiner Armaturen und Messgeraete OHG, Germany (0x482d) type: Heat Cost Allocator (0x08) ver: 0x55  for driver autodetection that use the same structure as INE HCA