### PR TITLE
feat: Add TAMPER status for TPL status bit 0x40

### DIFF
--- a/src/wmbus.cc
+++ b/src/wmbus.cc
@@ -5032,6 +5032,7 @@ string decodeTPLStatusByteOnlyStandardBits(uchar sts)
     if ((sts & 0x04) == 0x04) s += "POWER_LOW "; // E.g. battery end of life or external power supply failure
     if ((sts & 0x08) == 0x08) s += "PERMANENT_ERROR "; // E.g. meter needs service to work again.
     if ((sts & 0x10) == 0x10) s += "TEMPORARY_ERROR ";
+    if ((sts & 0x40) == 0x40) s += "TAMPER ";
 
     while (s.size() > 0 && s.back() == ' ') s.pop_back();
     return s;


### PR DESCRIPTION
This PR adds the definition for the standard TPL status bit 0x40 (Tamper) to decodeTPLStatusByteOnlyStandardBits in src/wmbus.cc.
This was discovered when an NFC read attempt on a BMETERS IWM-TX5 meter triggered an UNKNOWN_40 status. According to the EN 13757 standard, this bit corresponds to a "Tamper" or "Fraud Attempt" alarm.
This change fixes issue #1586.