### PR TITLE
New xmq driver for NZR EcoCount Compact electricity meters

### DIFF
--- a/drivers/src/nzr.xmq
+++ b/drivers/src/nzr.xmq
@@ -1,0 +1,197 @@
+// Copyright (C) 2024 Fredrik Öhrström (gpl-3.0-or-later)
+driver {
+    name           = nzr
+    default_fields = name,id,total_energy_consumption_kwh,current_power_consumption_kw,current_power_consumption_1_kw,current_power_consumption_2_kw,current_power_consumption_3_kw,voltage_at_phase_1_v,voltage_at_phase_2_v,voltage_at_phase_3_v,current_at_phase_1_a,current_at_phase_2_a,current_at_phase_3_a
+    meter_type     = ElectricityMeter
+    detect {
+        mvt = NZR,00,02
+        mvt = EMH,00,02
+    }
+    fields {
+        field {
+            name     = status
+            quantity = Text
+            info     = status_and_error_flags
+            match {
+                measurement_type = Instantaneous
+                vif_range        = ErrorFlags
+            }
+            lookup {
+                name            = ERROR_FLAGS
+                map_type        = BitToString
+                mask_bits       = 0xff
+                default_message = OK
+                map {
+                    name  = BUSY
+                    info  = 'System is busy'
+                    value = 0x01
+                    test  = Set
+                }
+                map {
+                    name  = GENERIC_APP_ERROR
+                    info  = 'Generic application error'
+                    value = 0x02
+                    test  = Set
+                }
+                map {
+                    name  = CURRENT_LOW
+                    info  = 'Current too low'
+                    value = 0x04
+                    test  = Set
+                }
+                map {
+                    name  = PERMANENT_ERROR
+                    info  = 'permanent error'
+                    value = 0x08
+                    test  = Set
+                }
+                map {
+                    name  = TEMPORARY_ERROR
+                    info  = 'temporary error'
+                    value = 0x10
+                    test  = Set
+                }
+            }
+        }
+        field {
+            name     = total_energy_consumption
+            quantity = Energy
+            info     = 'The total energy consumption recorded by this meter.'
+            match {
+                measurement_type = Instantaneous
+                vif_scaling      = Auto
+                vif_range        = AnyEnergyVIF
+                tariff_nr        = 1
+            }
+        }
+        field {
+            name     = current_power_consumption
+            quantity = Power
+            info     = 'active Power overall'
+            match {
+                measurement_type = Instantaneous
+                vif_scaling      = Auto
+                vif_range        = AnyPowerVIF
+            }
+        }
+        field {
+            name     = current_power_consumption_1
+            quantity = Power
+            info     = 'active Power in L1 phase'
+            match {
+                measurement_type = Instantaneous
+                vif_scaling      = Auto
+                vif_range        = AnyPowerVIF
+                storage_nr       = 2
+            }
+        }
+        field {
+            name     = voltage_at_phase_1
+            quantity = Voltage
+            info     = 'Instantaneous voltage between L1 and neutral.'
+            match {
+                measurement_type = Instantaneous
+                vif_scaling      = Auto
+                vif_range        = Voltage
+                storage_nr       = 2
+            }
+        }
+        field {
+            name     = current_at_phase_1
+            quantity = Amperage
+            info     = 'Instantaneous current in the L1 phase.'
+            match {
+                measurement_type = Instantaneous
+                vif_scaling      = Auto
+                vif_range        = Amperage
+                storage_nr       = 2
+            }
+        }
+        field {
+            name     = current_power_consumption_2
+            quantity = Power
+            info     = 'active Power in L2 phase'
+            match {
+                measurement_type = Instantaneous
+                vif_scaling      = Auto
+                vif_range        = AnyPowerVIF
+                storage_nr       = 4
+            }
+        }
+        field {
+            name     = voltage_at_phase_2
+            quantity = Voltage
+            info     = 'Instantaneous voltage between L2 and neutral.'
+            match {
+                measurement_type = Instantaneous
+                vif_scaling      = Auto
+                vif_range        = Voltage
+                storage_nr       = 4
+            }
+        }
+        field {
+            name     = current_at_phase_2
+            quantity = Amperage
+            info     = 'Instantaneous current in the L2 phase.'
+            match {
+                measurement_type = Instantaneous
+                vif_scaling      = Auto
+                vif_range        = Amperage
+                storage_nr       = 4
+            }
+        }
+        field {
+            name     = current_power_consumption_3
+            quantity = Power
+            info     = 'active Power in L3 phase'
+            match {
+                measurement_type = Instantaneous
+                vif_scaling      = Auto
+                vif_range        = AnyPowerVIF
+                storage_nr       = 6
+            }
+        }
+        field {
+            name     = voltage_at_phase_3
+            quantity = Voltage
+            info     = 'Instantaneous voltage between L3 and neutral.'
+            match {
+                measurement_type = Instantaneous
+                vif_scaling      = Auto
+                vif_range        = Voltage
+                storage_nr       = 6
+            }
+        }
+        field {
+            name     = current_at_phase_3
+            quantity = Amperage
+            info     = 'Instantaneous current in the L3 phase.'
+            match {
+                measurement_type = Instantaneous
+                vif_scaling      = Auto
+                vif_range        = Amperage
+                storage_nr       = 6
+            }
+        }
+    }
+    tests {
+        test {
+            args     = 'NZR nzr 07911459 NOKEY'
+            telegram = 685a5a68080B7259149107523B0002580000008c10058576490001fd170084002ccB00000084012962fB0000840229e85f010084032905Bf00008201fd49ed008202fd49e9008203fd49ea008201fd5a21018202fd5a8d018203fd5ad7009216
+            json     = '{"_":"telegram","media":"electricity","meter":"nzr","name":"NZR","id":"07911459","current_at_phase_1_a":2.89,"current_at_phase_2_a":3.97,"current_at_phase_3_a":2.15,"current_power_consumption_kw":2.03,"current_power_consumption_1_kw":0.64354,"current_power_consumption_2_kw":0.90088,"current_power_consumption_3_kw":0.48901,"total_energy_consumption_kwh":49768.5,"voltage_at_phase_1_v":237,"voltage_at_phase_2_v":233,"voltage_at_phase_3_v":234,"status":"OK","timestamp":"1111-11-11T11:11:11Z"}'
+            fields   = 'NZR;07911459;49768.5;2.03;0.64354;0.90088;0.48901;237;233;234;2.89;3.97;2.15'
+        }
+        //test {
+        //    args     = 'NZR nzr 07911459 NOKEY'
+        //    telegram = 68222268080B7259149107523B0002580000008c1005857649008400292f6a010001fd17001fd116
+        //    json     = '{"_":"telegram","current_power_consumption_kw":0.92719,"total_energy_consumption_kwh":49768.5,"status":"OK","timestamp":"1111-11-11T11:11:11Z"}'
+        //    fields   = 'NZR;07911459;49768.5;0.92719;null;null;null;null;null;null;null;null;null'
+        //}
+        //test {
+        //    args     = 'NZR nzr 07911459 NOKEY'
+        //    telegram = 684f4f68080B7259149117523B00029200000084002ccB00000084012962fB0000840229e85f010084032905Bf00008201fd49ed008202fd49e9008203fd49ea008201fd5a21018202fd5a8d018203fd5ad700e216
+        //    json     = '{"_":"telegram","current_at_phase_1_a":2.89,"current_at_phase_2_a":3.97,"current_at_phase_3_a":2.15,"current_power_consumption_kw":2.03,"current_power_consumption_1_kw":0.64354,"current_power_consumption_2_kw":0.90088,"current_power_consumption_3_kw":0.48901,"voltage_at_phase_1_v":237,"voltage_at_phase_2_v":233,"voltage_at_phase_3_v":234,"timestamp":"1111-11-11T11:11:11Z"}'
+        //    fields   = 'NZR;07911459;null;2.03;0.64354;0.90088;0.48901;237;233;234;2.89;3.97;2.15'
+        //}
+    }
+}


### PR DESCRIPTION
New driver for NZR EcoCount Compact electricity meters as amiplus driver is not fully matching.

Some details was here: https://github.com/wmbusmeters/wmbusmeters/issues/1040

https://www.nzr.de/leistungen/messtechnik/elektrizitaet/hutschiene-3/ecocount-compact
NZR M-Tool
https://www.nzr.de/fileadmin/user_upload/software/M-Tool_5.3.zip

PR for c++ driver https://github.com/wmbusmeters/wmbusmeters/pull/1594