### PR TITLE
Allow to specify index_nr in xmq drivers

### DIFF
--- a/src/driver_dynamic.cc
+++ b/src/driver_dynamic.cc
@@ -42,6 +42,7 @@ double check_force_scale(const char *force_scale, DriverDynamic *dd);
 bool checked_set_difvifkey(const char *difvifkey_s, FieldMatcher *fm, DriverDynamic *dd);
 void checked_set_measurement_type(const char *measurement_type_s, FieldMatcher *fm, DriverDynamic *dd);
 void checked_set_vif_range(const char *vif_range_s, FieldMatcher *fm, DriverDynamic *dd);
+void checked_set_indexnr(const char *indexnr_s, FieldMatcher *fm, DriverDynamic *dd);
 void checked_set_storagenr_range(const char *storagenr_range_s, FieldMatcher *fm, DriverDynamic *dd);
 void checked_set_tariffnr_range(const char *tariffnr_range_s, FieldMatcher *fm, DriverDynamic *dd);
 void checked_set_subunitnr_range(const char *subunitnr_range_s, FieldMatcher *fm, DriverDynamic *dd);
@@ -395,6 +396,7 @@ XMQProceed DriverDynamic::add_match(XMQDoc *doc, XMQNode *match, DriverDynamic *
 
     checked_set_vif_range(xmqGetStringRel(doc, "vif_range", match), fm, dd);
 
+    checked_set_indexnr(xmqGetStringRel(doc, "index_nr", match), fm, dd);
     checked_set_storagenr_range(xmqGetStringRel(doc, "storage_nr", match), fm, dd);
     checked_set_tariffnr_range(xmqGetStringRel(doc, "tariff_nr", match), fm, dd);
     checked_set_subunitnr_range(xmqGetStringRel(doc, "subunit_nr", match), fm, dd);
@@ -951,6 +953,24 @@ void checked_set_vif_range(const char *vif_range_s, FieldMatcher *fm, DriverDyna
     }
 
     fm->set(vif_range);
+}
+
+void checked_set_indexnr(const char *indexnr_s, FieldMatcher *fm, DriverDynamic *dd)
+{
+    if (!indexnr_s) return;
+
+    bool ok = isNumber(indexnr_s);
+    if (!ok)
+    {
+        warning("(driver) error in %s, bad indexnr: %s\n"
+                "%s\n",
+                dd->fileName().c_str(),
+                indexnr_s,
+                line);
+        throw 1;
+    }
+
+    fm->set(IndexNr(atoi(indexnr_s)));
 }
 
 void checked_set_storagenr_range(const char *storagenr_range_s, FieldMatcher *fm, DriverDynamic *dd)


### PR DESCRIPTION
During experiments with my new water meters I encountered packet like:

```
Auto driver    : iflux
Similar driver : iflux 39/90
Using driver   : iflux 00/00
017   : 02 dif (16 Bit Integer/Binary Instantaneous value)
018   : FD vif (Second extension FD of VIF-codes)
019   : 17 vife (Error flags (binary))
020 C!: 0000 ("status":"OK")
022   : 0D dif (variable length Instantaneous value)
023   : 78 vif (Fabrication no)
024   : 0D varlen=13
025 C!: 36303130343130353035323032 ("fabrication_no":"2025050140106")
038   : 04 dif (32 Bit Integer/Binary Instantaneous value)
039   : 12 vif (Volume 10⁻⁴ m³)
040 C!: AE580000 ("total_m3":2.2702)
044   : 04 dif (32 Bit Integer/Binary Instantaneous value)
045   : 12 vif (Volume 10⁻⁴ m³)
046 C!: 75000000 ("unknown_volume_m3":0.0117)
050   : 02 dif (16 Bit Integer/Binary Instantaneous value)
051   : 3B vif (Volume flow l/h)
052 C!: 0000 ("volume_flow_m3h":0)
054   : 12 dif (16 Bit Integer/Binary Maximum value)
055   : 3B vif (Volume flow l/h)
056 C!: 260A ("maximum_flow_m3h":2.598)
058   : 04 dif (32 Bit Integer/Binary Instantaneous value)
059   : 74 vif (Actuality duration seconds)
060 C!: 00000000 ("unknown_actuality1_h":0)
064   : 04 dif (32 Bit Integer/Binary Instantaneous value)
065   : 74 vif (Actuality duration seconds)
066 C!: 00000000 ("unknown_actuality2_h":0)
070   : 04 dif (32 Bit Integer/Binary Instantaneous value)
071   : 6D vif (Date and time type)
072 C!: 3212383B ("meter_datetime":"2025-11-24 18:50")
076 C?: 0F manufacturer specific data 01213BF3000000F3000000F1000000F1000000F2000000F9000000F9000000F9000000480100002F2F2F2F2F2F2F2F2F2F2F
```
As visible from the packet, there are simply mulptiple 0412 and 0474 DIF/VIF pairs. I assume I understand correctly, that such matchings are achieved using `IndexNr` matcher.
I wanted to implement it using xmq drivers as it seemed easier, but it lacked support for specifying `IndexNr` for the matcher.
I've added that.