### PR TITLE
fix(amb8465): prevent false protocol errors on RF noise/rx timeout

### DIFF
--- a/src/wmbus_amb8465.cc
+++ b/src/wmbus_amb8465.cc
@@ -752,8 +752,15 @@ void WMBusAmber::processSerialData()
         if (chunk_time.tv_sec >= 2)
         {
             verbose("(amb8465) rx long delay (%lds), drop incomplete telegram\n", chunk_time.tv_sec);
-            read_buffer_.clear();
-            protocolErrorDetected();
+
+            // Only trigger a protocol error if we were receiving a specific command response 
+            // from the stick (starts with AMBER_SERIAL_SOF).
+            if (read_buffer_.size() > 0 && read_buffer_[0] == AMBER_SERIAL_SOF)
+            {
+                protocolErrorDetected();
+            }
+
+            read_buffer_.clear(); 
         }
         else
         {


### PR DESCRIPTION
**Problem**
High RF noise causes frequent `rx long delay` events. The current implementation interprets 20 of such subsequent noise events as an error which trigger a reset of the device.

**Solution**
Improved the AMB8465 error handling to avoid aggressive resets on partial frames.

This partially fixes #1677 