### PR TITLE
Add stdin:json input format for per-telegram decryption keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,7 @@ PROG_OBJS:=\
 	$(BUILD)/wmbus_rtl433.o \
 	$(BUILD)/wmbus_simulator.o \
 	$(BUILD)/wmbus_rawtty.o \
+	$(BUILD)/wmbus_jsontty.o \
 	$(BUILD)/wmbus_rc1180.o \
 	$(BUILD)/wmbus_utils.o \
 	$(BUILD)/xmq.o \

--- a/src/bus.cc
+++ b/src/bus.cc
@@ -224,6 +224,10 @@ shared_ptr<BusDevice> BusManager::createWmbusObject(Detected *detected, Configur
         verbose("(hextty) on %s\n", detected->found_file.c_str());
         wmbus = openHexTTY(*detected, serial_manager_, serial_override);
         break;
+    case DEVICE_JSONTTY:
+        verbose("(jsontty) on %s\n", detected->found_file.c_str());
+        wmbus = openJsonTTY(*detected, serial_manager_, serial_override);
+        break;
     case DEVICE_RTLWMBUS:
         wmbus = openRTLWMBUS(*detected, config->bin_dir, config->daemon, serial_manager_, serial_override);
         break;

--- a/src/wmbus.cc
+++ b/src/wmbus.cc
@@ -5192,6 +5192,13 @@ bool is_type_id_extras(string t, BusDeviceType *out_type, string *out_id, string
         return true;
     }
 
+    if (t == "json")
+    {
+        *out_type = BusDeviceType::DEVICE_JSONTTY;
+        *out_id = "";
+        return true;
+    }
+
     size_t bs = t.find('[');
     size_t be = t.find(']');
 

--- a/src/wmbus.h
+++ b/src/wmbus.h
@@ -47,6 +47,7 @@ bool trimCRCsFrameFormatB(std::vector<uchar> &payload);
     X(IU891A,iu891a,true,false,detectIU891A)         \
     X(RAWTTY,rawtty,true,false,detectRAWTTY)         \
     X(HEXTTY,hextty,true,false,detectSKIP)           \
+    X(JSONTTY,jsontty,true,false,detectSKIP)         \
     X(RC1180,rc1180,true,false,detectRC1180)         \
     X(RTL433,rtl433,false,true,detectRTL433)         \
     X(RTLWMBUS,rtlwmbus,false,true,detectRTLWMBUS)   \
@@ -729,6 +730,9 @@ shared_ptr<BusDevice> openRawTTY(Detected detected,
                              shared_ptr<SerialCommunicationManager> manager,
                              shared_ptr<SerialDevice> serial_override);
 shared_ptr<BusDevice> openHexTTY(Detected detected,
+                             shared_ptr<SerialCommunicationManager> manager,
+                             shared_ptr<SerialDevice> serial_override);
+shared_ptr<BusDevice> openJsonTTY(Detected detected,
                              shared_ptr<SerialCommunicationManager> manager,
                              shared_ptr<SerialDevice> serial_override);
 shared_ptr<BusDevice> openMBUS(Detected detected,

--- a/src/wmbus_jsontty.cc
+++ b/src/wmbus_jsontty.cc
@@ -1,0 +1,432 @@
+/*
+ Copyright (C) 2024 Fredrik Öhrström (gpl-3.0-or-later)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include"wmbus.h"
+#include"wmbus_common_implementation.h"
+#include"wmbus_utils.h"
+#include"serial.h"
+#include"meters.h"
+#include"drivers.h"
+
+#include<assert.h>
+#include<pthread.h>
+#include<semaphore.h>
+#include<errno.h>
+#include<unistd.h>
+#include<sstream>
+#include<iomanip>
+#include<map>
+
+using namespace std;
+
+// Simple JSON string escaper
+static string escapeJsonString(const string &input)
+{
+    ostringstream ss;
+    for (char c : input)
+    {
+        switch (c)
+        {
+        case '"':  ss << "\\\""; break;
+        case '\\': ss << "\\\\"; break;
+        case '\b': ss << "\\b"; break;
+        case '\f': ss << "\\f"; break;
+        case '\n': ss << "\\n"; break;
+        case '\r': ss << "\\r"; break;
+        case '\t': ss << "\\t"; break;
+        default:
+            if ('\x00' <= c && c <= '\x1f')
+            {
+                ss << "\\u" << hex << setw(4) << setfill('0') << (int)c;
+            }
+            else
+            {
+                ss << c;
+            }
+        }
+    }
+    return ss.str();
+}
+
+// Simple JSON parser - extracts value for a given key
+static bool extractJsonString(const string &json, const string &key, string &value)
+{
+    string search = "\"" + key + "\"";
+    size_t pos = json.find(search);
+    if (pos == string::npos) return false;
+
+    pos = json.find(':', pos);
+    if (pos == string::npos) return false;
+
+    // Skip whitespace
+    pos++;
+    while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\t')) pos++;
+
+    if (pos >= json.size() || json[pos] != '"') return false;
+    pos++; // Skip opening quote
+
+    // Find closing quote
+    size_t end = pos;
+    while (end < json.size() && json[end] != '"')
+    {
+        if (json[end] == '\\' && end + 1 < json.size()) end += 2; // Skip escaped chars
+        else end++;
+    }
+
+    value = json.substr(pos, end - pos);
+    return true;
+}
+
+struct WMBusJsonTTY : public virtual BusDeviceCommonImplementation
+{
+    bool ping();
+    string getDeviceId();
+    string getDeviceUniqueId();
+    LinkModeSet getLinkModes();
+    void deviceReset();
+    bool deviceSetLinkModes(LinkModeSet lms);
+    LinkModeSet supportedLinkModes() { return Any_bit; }
+    int numConcurrentLinkModes() { return 0; }
+    bool canSetLinkModes(LinkModeSet desired_modes) { return true; }
+
+    void processSerialData();
+    void simulate() { }
+
+    WMBusJsonTTY(string bus_alias, shared_ptr<SerialDevice> serial,
+                 shared_ptr<SerialCommunicationManager> manager);
+    ~WMBusJsonTTY() { }
+
+private:
+    void processJsonLine(const string &line);
+    void outputError(const string &error_msg, const string &telegram_hex);
+    void outputResult(const string &json_result);
+
+    string line_buffer_;
+    LinkModeSet link_modes_;
+
+    // Cache entry: meter + last used key (to detect key changes)
+    struct CachedMeter
+    {
+        shared_ptr<Meter> meter;
+        string key;
+    };
+
+    // Cache meters by meter_id - driver is remembered in meter->driverName()
+    map<string, CachedMeter> meter_cache_;
+};
+
+shared_ptr<BusDevice> openJsonTTY(Detected detected,
+                                  shared_ptr<SerialCommunicationManager> manager,
+                                  shared_ptr<SerialDevice> serial_override)
+{
+    string bus_alias = detected.specified_device.bus_alias;
+    string device = detected.found_file;
+
+    if (serial_override)
+    {
+        WMBusJsonTTY *imp = new WMBusJsonTTY(bus_alias, serial_override, manager);
+        imp->markAsNoLongerSerial();
+        return shared_ptr<BusDevice>(imp);
+    }
+    auto serial = manager->createSerialDeviceTTY(device.c_str(), 0, PARITY::NONE, "jsontty");
+    WMBusJsonTTY *imp = new WMBusJsonTTY(bus_alias, serial, manager);
+    return shared_ptr<BusDevice>(imp);
+}
+
+WMBusJsonTTY::WMBusJsonTTY(string bus_alias, shared_ptr<SerialDevice> serial,
+                           shared_ptr<SerialCommunicationManager> manager) :
+    BusDeviceCommonImplementation(bus_alias, DEVICE_JSONTTY, manager, serial, true)
+{
+    reset();
+    // Load all drivers once at init, not for every telegram
+    loadAllBuiltinDrivers();
+}
+
+bool WMBusJsonTTY::ping()
+{
+    return true;
+}
+
+string WMBusJsonTTY::getDeviceId()
+{
+    return "?";
+}
+
+string WMBusJsonTTY::getDeviceUniqueId()
+{
+    return "?";
+}
+
+LinkModeSet WMBusJsonTTY::getLinkModes()
+{
+    return link_modes_;
+}
+
+void WMBusJsonTTY::deviceReset()
+{
+}
+
+bool WMBusJsonTTY::deviceSetLinkModes(LinkModeSet lms)
+{
+    return true;
+}
+
+void WMBusJsonTTY::outputError(const string &error_msg, const string &telegram_hex)
+{
+    printf("{\"error\": \"%s\"", escapeJsonString(error_msg).c_str());
+    if (!telegram_hex.empty())
+    {
+        printf(", \"telegram\": \"%s\"", telegram_hex.c_str());
+    }
+    printf("}\n");
+    fflush(stdout);
+}
+
+void WMBusJsonTTY::outputResult(const string &json_result)
+{
+    printf("%s\n", json_result.c_str());
+    fflush(stdout);
+}
+
+void WMBusJsonTTY::processJsonLine(const string &line)
+{
+    // Parse JSON input: {"telegram": "HEX", "key": "HEX", "driver": "auto", "format": "wmbus"}
+    string telegram_hex, key_hex, driver_name, format_str;
+
+    if (!extractJsonString(line, "telegram", telegram_hex))
+    {
+        outputError("missing 'telegram' field in JSON input", "");
+        return;
+    }
+
+    // Key is optional - can be empty or "NOKEY"
+    extractJsonString(line, "key", key_hex);
+    if (key_hex == "NOKEY") key_hex = "";
+
+    // Driver is optional - defaults to "auto"
+    if (!extractJsonString(line, "driver", driver_name))
+    {
+        driver_name = "auto";
+    }
+
+    // Format is optional - "wmbus", "mbus", or auto-detect if not specified
+    extractJsonString(line, "format", format_str);
+
+    // Convert hex to binary
+    vector<uchar> input_frame;
+    bool invalid_hex = false;
+    if (!isHexStringStrict(telegram_hex, &invalid_hex))
+    {
+        outputError("invalid hex string in 'telegram' field", telegram_hex);
+        return;
+    }
+    bool ok = hex2bin(telegram_hex, &input_frame);
+    if (!ok)
+    {
+        outputError("failed to decode hex telegram", telegram_hex);
+        return;
+    }
+
+    // Determine frame type
+    size_t frame_length;
+    int payload_len, payload_offset;
+    FrameType frame_type;
+
+    if (format_str == "wmbus")
+    {
+        // Explicit WMBUS - skip detection
+        frame_type = FrameType::WMBUS;
+    }
+    else if (format_str == "mbus")
+    {
+        // Explicit MBUS - skip detection
+        frame_type = FrameType::MBUS;
+        if (FullFrame == checkMBusFrame(input_frame, &frame_length, &payload_len, &payload_offset, true))
+        {
+            // Remove checksum and end marker for MBUS
+            while (((size_t)payload_len) < input_frame.size()) input_frame.pop_back();
+        }
+    }
+    else
+    {
+        // Auto-detect: try WMBUS first (more common), fall back to MBUS
+        if (FullFrame == checkWMBusFrame(input_frame, &frame_length, &payload_len, &payload_offset, true))
+        {
+            frame_type = FrameType::WMBUS;
+        }
+        else if (FullFrame == checkMBusFrame(input_frame, &frame_length, &payload_len, &payload_offset, true))
+        {
+            frame_type = FrameType::MBUS;
+            // Remove checksum and end marker for MBUS
+            while (((size_t)payload_len) < input_frame.size()) input_frame.pop_back();
+        }
+        else
+        {
+            // Neither detected - try as WMBUS (let parser handle error)
+            frame_type = FrameType::WMBUS;
+        }
+    }
+
+    // Parse telegram header
+    Telegram t;
+    AboutTelegram about("", 0, LinkMode::UNKNOWN, frame_type);
+    t.about = about;
+
+    ok = t.parseHeader(input_frame);
+    if (!ok)
+    {
+        outputError("failed to parse telegram header", telegram_hex);
+        return;
+    }
+
+    // Get meter ID from telegram
+    string meter_id = t.addresses.back().id;
+
+    // Try to find meter in cache by meter_id
+    shared_ptr<Meter> meter;
+    auto it = meter_cache_.find(meter_id);
+
+    bool need_new_meter = (it == meter_cache_.end());
+
+    if (!need_new_meter)
+    {
+        // Found cached meter - check if key changed
+        if (it->second.key == key_hex)
+        {
+            // Same key, reuse meter (driver is already resolved)
+            meter = it->second.meter;
+        }
+        else
+        {
+            // Key changed, need to create new meter
+            need_new_meter = true;
+        }
+    }
+
+    if (need_new_meter)
+    {
+        // Find best driver if auto (only when creating new meter)
+        if (driver_name == "auto")
+        {
+            DriverInfo auto_di = pickMeterDriver(&t);
+            if (auto_di.name().str() != "")
+            {
+                driver_name = auto_di.name().str();
+            }
+            else
+            {
+                driver_name = "unknown";
+            }
+        }
+
+        // Create new meter and cache it
+        MeterInfo mi;
+        mi.key = key_hex;
+        mi.address_expressions.clear();
+        mi.address_expressions.push_back(AddressExpression(t.addresses.back()));
+        mi.identity_mode = IdentityMode::ID;
+        mi.driver_name = DriverName(driver_name);
+        mi.poll_interval = 1000*1000*1000;  // Fake a high value to silence warning
+
+        meter = createMeter(&mi);
+        if (meter == NULL)
+        {
+            outputError("failed to create meter", telegram_hex);
+            return;
+        }
+
+        CachedMeter cached;
+        cached.meter = meter;
+        cached.key = key_hex;
+        meter_cache_[meter_id] = cached;
+    }
+
+    bool match = false;
+    vector<Address> addresses;
+    Telegram out_telegram;
+    bool handled = meter->handleTelegram(about, input_frame, false, &addresses, &match, &out_telegram);
+
+    // Generate output
+    string hr, fields, json;
+    vector<string> envs, more_json, selected_fields;
+    meter->printMeter(&out_telegram, &hr, &fields, '\t', &json, &envs, &more_json, &selected_fields, true);
+
+    // Check parse quality - how much of the content was understood (in bytes)
+    int content_bytes = 0, understood_bytes = 0;
+    out_telegram.analyzeParse(OutputFormat::NONE, &content_bytes, &understood_bytes);
+
+    if (!handled)
+    {
+        // Add error info to JSON
+        if (!json.empty() && json.back() == '}')
+        {
+            json.pop_back();
+        }
+
+        if (out_telegram.decryption_failed)
+        {
+            json += ", \"error\": \"decryption failed, please check key\"";
+        }
+        else
+        {
+            string analyze_output = out_telegram.analyzeParse(OutputFormat::PLAIN, &content_bytes, &understood_bytes);
+            json += ", \"error\": \"decoding failed\", \"error_analyze\": \"" + escapeJsonString(analyze_output) + "\"";
+        }
+
+        json += ", \"telegram\": \"" + telegram_hex + "\"";
+        json += "}";
+    }
+    else if (content_bytes > 0 && understood_bytes < content_bytes)
+    {
+        // Telegram was handled but not fully understood - add warning with byte counts
+        if (!json.empty() && json.back() == '}')
+        {
+            json.pop_back();
+            json += ", \"warning\": \"telegram only partially decoded (" +
+                    to_string(understood_bytes) + " of " + to_string(content_bytes) + " bytes)\"";
+            json += ", \"telegram\": \"" + telegram_hex + "\"}";
+        }
+    }
+
+    outputResult(json);
+}
+
+void WMBusJsonTTY::processSerialData()
+{
+    vector<uchar> data;
+
+    // Receive serial data
+    serial()->receive(&data);
+
+    // Append to line buffer
+    for (uchar c : data)
+    {
+        if (c == '\n')
+        {
+            // Process complete line
+            if (!line_buffer_.empty())
+            {
+                processJsonLine(line_buffer_);
+                line_buffer_.clear();
+            }
+        }
+        else if (c != '\r')
+        {
+            line_buffer_ += (char)c;
+        }
+    }
+}

--- a/test.sh
+++ b/test.sh
@@ -190,6 +190,9 @@ if [ "$?" != "0" ]; then RC="1"; fi
 ./tests/test_hex_cmdline.sh $PROG
 if [ "$?" != "0" ]; then RC="1"; fi
 
+./tests/test_json_stdin.sh $PROG
+if [ "$?" != "0" ]; then RC="1"; fi
+
 ./tests/test_removing_dll_crcs.sh $PROG
 if [ "$?" != "0" ]; then RC="1"; fi
 

--- a/tests/test_alarm.sh
+++ b/tests/test_alarm.sh
@@ -9,6 +9,11 @@ TESTRESULT="OK"
 
 echo "RUNNING $TESTNAME ..."
 
+# Kill any leftover wmbusmeters processes that might hold the files
+pkill -f "wmbusmeters.*config7" 2>/dev/null || true
+sleep 0.1
+
+# Clean up files from previous runs
 > /tmp/wmbusmeters_telegram_test
 > /tmp/wmbusmeters_alarm_test
 

--- a/tests/test_json_stdin.sh
+++ b/tests/test_json_stdin.sh
@@ -1,0 +1,227 @@
+#!/bin/sh
+
+PROG="$1"
+TEST=testoutput
+mkdir -p $TEST
+
+TESTNAME="Test json on stdin with single telegram"
+TESTRESULT="ERROR"
+
+cat > $TEST/test_expected_unsorted.txt <<EOF
+{"_":"telegram","media":"cold water","meter":"multical21","name":"","id":"76348799","status":"DRY","total_m3":6.408,"target_m3":6.408,"flow_temperature_c":127,"external_temperature_c":19,"current_status":"DRY","time_dry":"22-31 days","time_reversed":"","time_leaking":"","time_bursting":"","timestamp":"1111-11-11T11:11:11Z"}
+EOF
+
+jq --sort-keys . $TEST/test_expected_unsorted.txt > $TEST/test_expected.txt
+
+echo '{"telegram": "2A442D2C998734761B168D2091D37CAC21E1D68CDAFFCD3DC452BD802913FF7B1706CA9E355D6C2701CC24", "key": "28F64A24988064A079AA2C807D6102AE"}' | \
+    $PROG --silent --format=json stdin:json 2> $TEST/test_stderr.txt | jq --sort-keys . > $TEST/test_output.txt
+
+if [ "$?" = "0" ]
+then
+    cat $TEST/test_output.txt | sed 's/"timestamp": "....-..-..T..:..:..Z"/"timestamp": "1111-11-11T11:11:11Z"/' > $TEST/test_responses.txt
+    diff $TEST/test_expected.txt $TEST/test_responses.txt
+    if [ "$?" = "0" ]
+    then
+        echo OK: $TESTNAME
+        TESTRESULT="OK"
+    else
+        echo "ERROR: $TESTNAME"
+        echo "Expected:"
+        cat $TEST/test_expected.txt
+        echo "Got:"
+        cat $TEST/test_responses.txt
+        exit 1
+    fi
+else
+    echo "ERROR: $TESTNAME"
+    echo "wmbusmeters returned error code: $?"
+    cat $TEST/test_output.txt
+    cat $TEST/test_stderr.txt
+    exit 1
+fi
+
+
+TESTNAME="Test json on stdin with multiple telegrams and different keys"
+
+cat > $TEST/test_expected_unsorted.txt <<EOF
+{"_":"telegram","media":"cold water","meter":"multical21","name":"","id":"76348799","status":"DRY","total_m3":6.408,"target_m3":6.408,"flow_temperature_c":127,"external_temperature_c":19,"current_status":"DRY","time_dry":"22-31 days","time_reversed":"","time_leaking":"","time_bursting":"","timestamp":"1111-11-11T11:11:11Z"}
+{"_":"telegram","media":"other","meter":"lansenpu","name":"","id":"00010206","status":"OK","a_counter":4711,"b_counter":1234,"timestamp":"1111-11-11T11:11:11Z"}
+EOF
+
+jq --sort-keys . $TEST/test_expected_unsorted.txt > $TEST/test_expected.txt
+
+cat > $TEST/test_input.txt <<EOF
+{"telegram": "2A442D2C998734761B168D2091D37CAC21E1D68CDAFFCD3DC452BD802913FF7B1706CA9E355D6C2701CC24", "key": "28F64A24988064A079AA2C807D6102AE"}
+{"telegram": "234433300602010014007a8e0000002f2f0efd3a1147000000008e40fd3a341200000000", "key": "NOKEY"}
+EOF
+
+cat $TEST/test_input.txt | \
+    $PROG --silent --format=json stdin:json 2> $TEST/test_stderr.txt | jq --sort-keys . > $TEST/test_output.txt
+
+if [ "$?" = "0" ]
+then
+    cat $TEST/test_output.txt | sed 's/"timestamp": "....-..-..T..:..:..Z"/"timestamp": "1111-11-11T11:11:11Z"/' > $TEST/test_responses.txt
+    diff $TEST/test_expected.txt $TEST/test_responses.txt
+    if [ "$?" = "0" ]
+    then
+        echo OK: $TESTNAME
+        TESTRESULT="OK"
+    else
+        echo "ERROR: $TESTNAME"
+        echo "Expected:"
+        cat $TEST/test_expected.txt
+        echo "Got:"
+        cat $TEST/test_responses.txt
+        exit 1
+    fi
+else
+    echo "ERROR: $TESTNAME"
+    echo "wmbusmeters returned error code: $?"
+    cat $TEST/test_output.txt
+    cat $TEST/test_stderr.txt
+    exit 1
+fi
+
+
+TESTNAME="Test json on stdin with wrong key (decryption error)"
+
+cat > $TEST/test_expected_unsorted.txt <<EOF
+{"_":"telegram","media":"cold water","meter":"multical21","name":"","id":"76348799","error":"decryption failed, please check key","telegram":"2A442D2C998734761B168D2091D37CAC21E1D68CDAFFCD3DC452BD802913FF7B1706CA9E355D6C2701CC24","timestamp":"1111-11-11T11:11:11Z"}
+EOF
+
+jq --sort-keys . $TEST/test_expected_unsorted.txt > $TEST/test_expected.txt
+
+echo '{"telegram": "2A442D2C998734761B168D2091D37CAC21E1D68CDAFFCD3DC452BD802913FF7B1706CA9E355D6C2701CC24", "key": "00000000000000000000000000000000"}' | \
+    $PROG --silent --format=json stdin:json 2> $TEST/test_stderr.txt | jq --sort-keys . > $TEST/test_output.txt
+
+if [ "$?" = "0" ]
+then
+    cat $TEST/test_output.txt | sed 's/"timestamp": "....-..-..T..:..:..Z"/"timestamp": "1111-11-11T11:11:11Z"/' > $TEST/test_responses.txt
+    diff $TEST/test_expected.txt $TEST/test_responses.txt
+    if [ "$?" = "0" ]
+    then
+        echo OK: $TESTNAME
+        TESTRESULT="OK"
+    else
+        echo "ERROR: $TESTNAME"
+        echo "Expected:"
+        cat $TEST/test_expected.txt
+        echo "Got:"
+        cat $TEST/test_responses.txt
+        exit 1
+    fi
+else
+    echo "ERROR: $TESTNAME"
+    echo "wmbusmeters returned error code: $?"
+    cat $TEST/test_output.txt
+    cat $TEST/test_stderr.txt
+    exit 1
+fi
+
+
+TESTNAME="Test json on stdin with explicit driver"
+
+cat > $TEST/test_expected_unsorted.txt <<EOF
+{"_":"telegram","media":"cold water","meter":"multical21","name":"","id":"76348799","status":"DRY","total_m3":6.408,"target_m3":6.408,"flow_temperature_c":127,"external_temperature_c":19,"current_status":"DRY","time_dry":"22-31 days","time_reversed":"","time_leaking":"","time_bursting":"","timestamp":"1111-11-11T11:11:11Z"}
+EOF
+
+jq --sort-keys . $TEST/test_expected_unsorted.txt > $TEST/test_expected.txt
+
+echo '{"telegram": "2A442D2C998734761B168D2091D37CAC21E1D68CDAFFCD3DC452BD802913FF7B1706CA9E355D6C2701CC24", "key": "28F64A24988064A079AA2C807D6102AE", "driver": "multical21"}' | \
+    $PROG --silent --format=json stdin:json 2> $TEST/test_stderr.txt | jq --sort-keys . > $TEST/test_output.txt
+
+if [ "$?" = "0" ]
+then
+    cat $TEST/test_output.txt | sed 's/"timestamp": "....-..-..T..:..:..Z"/"timestamp": "1111-11-11T11:11:11Z"/' > $TEST/test_responses.txt
+    diff $TEST/test_expected.txt $TEST/test_responses.txt
+    if [ "$?" = "0" ]
+    then
+        echo OK: $TESTNAME
+        TESTRESULT="OK"
+    else
+        echo "ERROR: $TESTNAME"
+        echo "Expected:"
+        cat $TEST/test_expected.txt
+        echo "Got:"
+        cat $TEST/test_responses.txt
+        exit 1
+    fi
+else
+    echo "ERROR: $TESTNAME"
+    echo "wmbusmeters returned error code: $?"
+    cat $TEST/test_output.txt
+    cat $TEST/test_stderr.txt
+    exit 1
+fi
+
+
+TESTNAME="Test json on stdin with partial decode warning"
+
+cat > $TEST/test_expected_unsorted.txt <<EOF
+{"_":"telegram","media":"heat cost allocation","meter":"hydroclima","name":"","id":"68036198","current_consumption_hca":0,"average_ambient_temperature_c":18.66,"max_ambient_temperature_c":47.51,"average_ambient_temperature_last_month_c":15.78,"average_heater_temperature_last_month_c":17.47,"warning":"telegram only partially decoded (26 of 51 bytes)","telegram":"2e44b0099861036853087a000020002F2F036E0000000F100043106A7D2C4A078F12202CB1242A06D3062100210000","timestamp":"1111-11-11T11:11:11Z"}
+EOF
+
+jq --sort-keys . $TEST/test_expected_unsorted.txt > $TEST/test_expected.txt
+
+echo '{"telegram": "2e44b0099861036853087a000020002F2F036E0000000F100043106A7D2C4A078F12202CB1242A06D3062100210000", "key": "NOKEY"}' | \
+    $PROG --silent --format=json stdin:json 2> $TEST/test_stderr.txt | jq --sort-keys . > $TEST/test_output.txt
+
+if [ "$?" = "0" ]
+then
+    cat $TEST/test_output.txt | sed 's/"timestamp": "....-..-..T..:..:..Z"/"timestamp": "1111-11-11T11:11:11Z"/' > $TEST/test_responses.txt
+    diff $TEST/test_expected.txt $TEST/test_responses.txt
+    if [ "$?" = "0" ]
+    then
+        echo OK: $TESTNAME
+        TESTRESULT="OK"
+    else
+        echo "ERROR: $TESTNAME"
+        echo "Expected:"
+        cat $TEST/test_expected.txt
+        echo "Got:"
+        cat $TEST/test_responses.txt
+        exit 1
+    fi
+else
+    echo "ERROR: $TESTNAME"
+    echo "wmbusmeters returned error code: $?"
+    cat $TEST/test_output.txt
+    cat $TEST/test_stderr.txt
+    exit 1
+fi
+
+
+TESTNAME="Test json on stdin with MBUS telegram (auto-detected)"
+
+cat > $TEST/test_expected_unsorted.txt <<EXPECTED
+{"_":"telegram","media":"room sensor","meter":"piigth","name":"","id":"10000284","average_temperature_1h_c":23.52,"average_temperature_24h_c":22.79,"relative_humidity_rh":32.8,"relative_humidity_1h_rh":32.5,"relative_humidity_24h_rh":33.4,"temperature_c":23.02,"fabrication_no":"10000284","software_version":"0021","status":"OK","warning":"telegram only partially decoded (18 of 19 bytes)","telegram":"68383868080072840200102941011B0D0000000265FE0842653009820165E70802FB1A480142FB1A45018201FB1A4E010C788402001002FD0F21000F0316","timestamp":"1111-11-11T11:11:11Z"}
+EXPECTED
+
+jq --sort-keys . $TEST/test_expected_unsorted.txt > $TEST/test_expected.txt
+
+echo '{"telegram": "68383868080072840200102941011B0D0000000265FE0842653009820165E70802FB1A480142FB1A45018201FB1A4E010C788402001002FD0F21000F0316", "key": "NOKEY"}' | \
+    $PROG --format=json stdin:json 2> $TEST/test_stderr.txt | jq --sort-keys . > $TEST/test_output.txt
+
+if [ "$?" = "0" ]
+then
+    cat $TEST/test_output.txt | sed 's/"timestamp": "....-..-..T..:..:..Z"/"timestamp": "1111-11-11T11:11:11Z"/' > $TEST/test_responses.txt
+    diff $TEST/test_expected.txt $TEST/test_responses.txt
+    if [ "$?" = "0" ]
+    then
+        echo OK: $TESTNAME
+        TESTRESULT="OK"
+    else
+        echo "ERROR: $TESTNAME"
+        echo "Expected:"
+        cat $TEST/test_expected.txt
+        echo "Got:"
+        cat $TEST/test_responses.txt
+        exit 1
+    fi
+else
+    echo "ERROR: $TESTNAME"
+    echo "wmbusmeters returned error code: $?"
+    cat $TEST/test_output.txt
+    cat $TEST/test_stderr.txt
+    exit 1
+fi


### PR DESCRIPTION
Allows passing telegram data as JSON with individual decryption keys, enabling dynamic key management without pre-configured meters.

Input format: {"telegram": "HEX", "key": "KEY", "driver": "auto", "format": "wmbus|mbus"}

Supports both WMBUS and MBUS telegrams with auto-detection.