### PR TITLE
Add --decodingserver=PORT for TCP-based telegram decoding

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,33 @@
+FROM alpine AS build
+RUN apk add --no-cache alpine-sdk gcc linux-headers libxml2-dev libxslt-dev cmake libusb-dev bash samurai jq netcat-openbsd python3
+
+# Build librtlsdr from source (required dependency)
+RUN git clone --depth 1 https://github.com/steve-m/librtlsdr.git /librtlsdr
+WORKDIR /librtlsdr
+RUN cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=MinSizeRel \
+        -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+        -DDETACH_KERNEL_DRIVER=ON \
+        -Wno-dev && \
+    cmake --build build -j `nproc` && \
+    cmake --install build
+
+# Build xmq tool (needed for tests)
+RUN git clone --depth 1 https://github.com/libxmq/xmq.git /xmq
+WORKDIR /xmq
+RUN ./configure && make -j`nproc`
+
+# Copy local source
+COPY . /wmbusmeters
+WORKDIR /wmbusmeters
+
+# Clean any host build artifacts then prepare build dir
+RUN rm -rf build build_debug build_arm && \
+    mkdir -p build && \
+    cp /xmq/build/default/release/xmq build/xmq
+
+# Build wmbusmeters
+RUN make -j`nproc`
+
+# Run tests
+RUN make test

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,8 @@ PROG_OBJS:=\
 	$(BUILD)/bus.o \
 	$(BUILD)/cmdline.o \
 	$(BUILD)/config.o \
+	$(BUILD)/decode.o \
+	$(BUILD)/decoding_server.o \
 	$(BUILD)/drivers.o \
 	$(BUILD)/dvparser.o \
 	$(BUILD)/formula.o \

--- a/examples/decoding_client.py
+++ b/examples/decoding_client.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Example client for the wmbusmeters decoding server.
+
+Start the server:
+    wmbusmeters --decodingserver=12345
+
+Then run this script:
+    python3 decoding_client.py
+
+Protocol: JSON Lines over TCP — one JSON request per line, one JSON response per line.
+"""
+
+import json
+import socket
+
+
+def decode_telegram(host, port, telegram_hex, key="NOKEY", driver="auto", fmt=None):
+    """Send a single decode request and return the parsed JSON response."""
+    request = {
+        "_": "decode",
+        "telegram": telegram_hex,
+        "key": key,
+        "driver": driver,
+    }
+    if fmt:
+        request["format"] = fmt
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(5.0)
+    sock.connect((host, port))
+
+    # One JSON object per line in, one JSON object per line out.
+    sock.sendall((json.dumps(request) + "\n").encode())
+
+    buf = b""
+    while b"\n" not in buf:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        buf += chunk
+    sock.close()
+
+    line = buf.split(b"\n", 1)[0]
+    return json.loads(line.decode())
+
+
+class DecodingSession:
+    """Persistent connection for sending multiple decode requests.
+
+    The server uses per-client meter caching, so reusing a connection
+    is more efficient when decoding multiple telegrams from the same meters.
+    """
+
+    def __init__(self, host="localhost", port=12345):
+        self.host = host
+        self.port = port
+        self.sock = None
+        self._buf = b""
+
+    def connect(self):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.settimeout(5.0)
+        self.sock.connect((self.host, self.port))
+        self._buf = b""
+
+    def close(self):
+        if self.sock:
+            self.sock.close()
+            self.sock = None
+
+    def decode(self, telegram_hex, key="NOKEY", driver="auto", fmt=None):
+        """Send a decode request over the persistent connection."""
+        if not self.sock:
+            self.connect()
+
+        request = {
+            "_": "decode",
+            "telegram": telegram_hex,
+            "key": key,
+            "driver": driver,
+        }
+        if fmt:
+            request["format"] = fmt
+
+        self.sock.sendall((json.dumps(request) + "\n").encode())
+
+        # Read until we get a complete response line.
+        while b"\n" not in self._buf:
+            chunk = self.sock.recv(4096)
+            if not chunk:
+                raise ConnectionError("Server closed connection")
+            self._buf += chunk
+
+        line, self._buf = self._buf.split(b"\n", 1)
+        return json.loads(line.decode())
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+if __name__ == "__main__":
+    HOST = "localhost"
+    PORT = 12345
+
+    # --- Example 1: Single request using the helper function ---
+    print("=== Single request ===")
+    result = decode_telegram(
+        HOST, PORT,
+        telegram_hex="1844AE4C4455223368077A55000000041389E20100023B0000",
+        driver="iperl",
+    )
+    print(json.dumps(result, indent=2))
+    print(f"Meter: {result.get('meter')}, Total: {result.get('total_m3')} m3")
+
+    # --- Example 2: Multiple requests over a persistent connection ---
+    print("\n=== Persistent session with multiple requests ===")
+    telegrams = [
+        # iperl water meter (no encryption)
+        ("1844AE4C4455223368077A55000000041389E20100023B0000", "NOKEY", "auto"),
+        # multical21 water meter (encrypted)
+        ("2A442D2C998734761B168D2091D37CAC21E1D68CDAFFCD3DC452BD802913FF7B1706CA9E355D6C2701CC24",
+         "28F64A24988064A079AA2C807D6102AE", "auto"),
+    ]
+
+    with DecodingSession(HOST, PORT) as session:
+        for hex_data, key, drv in telegrams:
+            result = session.decode(hex_data, key=key, driver=drv)
+            meter = result.get("meter", "?")
+            meter_id = result.get("id", "?")
+            fields = {k: v for k, v in result.items() if k not in ("_", "timestamp")}
+            print(f"  {meter} (id={meter_id}): {json.dumps(fields)}")

--- a/src/cmdline.cc
+++ b/src/cmdline.cc
@@ -712,6 +712,17 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             loadDriver(file_name, NULL);
             continue;
         }
+        if (!strncmp(argv[i], "--decodingserver=", 17) && strlen(argv[i]) > 17)
+        {
+            int port = atoi(argv[i]+17);
+            if (port < 1 || port > 65535)
+            {
+                error("Not a valid port number \"%s\". Must be 1-65535.\n", argv[i]+17);
+            }
+            c->decoding_server_port = port;
+            i++;
+            continue;
+        }
 
         error("Unknown option \"%s\"\n", argv[i]);
     }
@@ -747,7 +758,8 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         !c->list_fields &&
         !c->list_meters &&
         !c->list_units &&
-        !c->print_driver)
+        !c->print_driver &&
+        c->decoding_server_port == 0)
     {
         error("You must supply at least one device to communicate using (w)mbus.\n");
     }

--- a/src/config.h
+++ b/src/config.h
@@ -147,6 +147,7 @@ struct Configuration
     // These extra constant fields can also be part of selected with selectfields.
     std::vector<SendBusContent> send_bus_content; // Telegrams used to wake up a meter for reading or mbus read-out requests.
     std::set<BusDeviceType> probe_for; // Which devices should be probed for? DEVICE_AUTO means all.
+    int decoding_server_port {}; // If > 0, run a TCP decoding server on this port.
     ~Configuration() = default;
 };
 

--- a/src/decode.cc
+++ b/src/decode.cc
@@ -1,0 +1,285 @@
+/*
+ Copyright (C) 2024-2026 Fredrik Öhrström (gpl-3.0-or-later)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include"decode.h"
+#include"drivers.h"
+#include"wmbus.h"
+#include"wmbus_utils.h"
+#include"xmq.h"
+
+#include<iomanip>
+#include<sstream>
+#include<string.h>
+
+using namespace std;
+
+string escapeJsonString(const string &input)
+{
+    ostringstream ss;
+    for (char c : input)
+    {
+        switch (c)
+        {
+        case '"':  ss << "\\\""; break;
+        case '\\': ss << "\\\\"; break;
+        case '\b': ss << "\\b"; break;
+        case '\f': ss << "\\f"; break;
+        case '\n': ss << "\\n"; break;
+        case '\r': ss << "\\r"; break;
+        case '\t': ss << "\\t"; break;
+        default:
+            if ('\x00' <= c && c <= '\x1f')
+            {
+                ss << "\\u" << hex << setw(4) << setfill('0') << (int)c;
+            }
+            else
+            {
+                ss << c;
+            }
+        }
+    }
+    return ss.str();
+}
+
+static string formatError(const string &error_msg, const string &telegram_hex)
+{
+    string result = "{\"error\": \"" + escapeJsonString(error_msg) + "\"";
+    if (!telegram_hex.empty())
+    {
+        result += ", \"telegram\": \"" + telegram_hex + "\"";
+    }
+    result += "}";
+    return result;
+}
+
+string decodeLine(DecoderSession &session, const string &line)
+{
+    // Parse JSON input: {"_": "decode", "telegram": "HEX", "key": "HEX", "driver": "auto", "format": "wmbus"}
+    // Parse XMQ  input: decode{telegram=HEX key=HEX driver=auto format=wmbus}
+    // Parse XML  input: <decode><telegram>HEX</telegram><key>HEX</key><driver>auto</driver><format>wmbus</format></decode>
+    XMQDoc *doc = xmqNewDoc();
+    bool ok = xmqParseBufferWithType(doc, line.c_str(), line.c_str()+line.length(), NULL, XMQ_CONTENT_DETECT, 0);
+
+    if (!ok)
+    {
+        string error = xmqDocError(doc);
+        string result = formatError(error, "");
+        xmqFreeDoc(doc);
+        return result;
+    }
+
+    string telegram_hex, key_hex, driver_name, format_str;
+
+    const char *telegram_hex_s = xmqGetString(doc, "/decode/telegram");
+    if (!telegram_hex_s)
+    {
+        xmqFreeDoc(doc);
+        return formatError("missing 'telegram' field in JSON input", "");
+    }
+    telegram_hex = telegram_hex_s;
+
+    // Key is optional - can be empty or "NOKEY"
+    const char *key_hex_s = xmqGetString(doc, "/decode/key");
+    if (key_hex_s == NULL || !strcmp(key_hex_s, "NOKEY")) key_hex = "";
+    else key_hex = key_hex_s;
+
+    // Driver is optional - defaults to "auto"
+    const char *driver_name_s = xmqGetString(doc, "/decode/driver");
+    if (driver_name_s == NULL) driver_name = "auto";
+    else driver_name = driver_name_s;
+
+    // Format is optional - "wmbus", "mbus", or auto-detect if not specified
+    const char *format_s = xmqGetString(doc, "/decode/format");
+    if (format_s == NULL) format_str = "";
+    else format_str = format_s;
+
+    xmqFreeDoc(doc);
+
+    // Convert hex to binary
+    vector<uchar> input_frame;
+    bool invalid_hex = false;
+    if (!isHexStringStrict(telegram_hex, &invalid_hex))
+    {
+        return formatError("invalid hex string in 'telegram' field", telegram_hex);
+    }
+    ok = hex2bin(telegram_hex, &input_frame);
+    if (!ok)
+    {
+        return formatError("failed to decode hex telegram", telegram_hex);
+    }
+
+    // Determine frame type
+    size_t frame_length;
+    int payload_len, payload_offset;
+    FrameType frame_type;
+
+    if (format_str == "wmbus")
+    {
+        // Explicit WMBUS - skip detection
+        frame_type = FrameType::WMBUS;
+    }
+    else if (format_str == "mbus")
+    {
+        // Explicit MBUS - skip detection
+        frame_type = FrameType::MBUS;
+        if (FullFrame == checkMBusFrame(input_frame, &frame_length, &payload_len, &payload_offset, true))
+        {
+            // Remove checksum and end marker for MBUS
+            while (((size_t)payload_len) < input_frame.size()) input_frame.pop_back();
+        }
+    }
+    else
+    {
+        // Auto-detect: try WMBUS first (more common), fall back to MBUS
+        if (FullFrame == checkWMBusFrame(input_frame, &frame_length, &payload_len, &payload_offset, true))
+        {
+            frame_type = FrameType::WMBUS;
+        }
+        else if (FullFrame == checkMBusFrame(input_frame, &frame_length, &payload_len, &payload_offset, true))
+        {
+            frame_type = FrameType::MBUS;
+            // Remove checksum and end marker for MBUS
+            while (((size_t)payload_len) < input_frame.size()) input_frame.pop_back();
+        }
+        else
+        {
+            // Neither detected - try as WMBUS (let parser handle error)
+            frame_type = FrameType::WMBUS;
+        }
+    }
+
+    // Parse telegram header
+    Telegram t;
+    AboutTelegram about("", 0, LinkMode::UNKNOWN, frame_type);
+    t.about = about;
+
+    ok = t.parseHeader(input_frame);
+    if (!ok)
+    {
+        return formatError("failed to parse telegram header", telegram_hex);
+    }
+
+    // Get meter ID from telegram
+    string meter_id = t.addresses.back().id;
+
+    // Try to find meter in cache by meter_id
+    shared_ptr<Meter> meter;
+    auto it = session.meter_cache.find(meter_id);
+
+    bool need_new_meter = (it == session.meter_cache.end());
+
+    if (!need_new_meter)
+    {
+        // Found cached meter - check if key changed
+        if (it->second.key == key_hex)
+        {
+            // Same key, reuse meter (driver is already resolved)
+            meter = it->second.meter;
+        }
+        else
+        {
+            // Key changed, need to create new meter
+            need_new_meter = true;
+        }
+    }
+
+    if (need_new_meter)
+    {
+        // Find best driver if auto (only when creating new meter)
+        if (driver_name == "auto")
+        {
+            DriverInfo auto_di = pickMeterDriver(&t);
+            if (auto_di.name().str() != "")
+            {
+                driver_name = auto_di.name().str();
+            }
+            else
+            {
+                driver_name = "unknown";
+            }
+        }
+
+        // Create new meter and cache it
+        MeterInfo mi;
+        mi.key = key_hex;
+        mi.address_expressions.clear();
+        mi.address_expressions.push_back(AddressExpression(t.addresses.back()));
+        mi.identity_mode = IdentityMode::ID;
+        mi.driver_name = DriverName(driver_name);
+        mi.poll_interval = 1000*1000*1000;  // Fake a high value to silence warning
+
+        meter = createMeter(&mi);
+        if (meter == NULL)
+        {
+            return formatError("failed to create meter", telegram_hex);
+        }
+
+        CachedMeter cached;
+        cached.meter = meter;
+        cached.key = key_hex;
+        session.meter_cache[meter_id] = cached;
+    }
+
+    bool match = false;
+    vector<Address> addresses;
+    Telegram out_telegram;
+    bool handled = meter->handleTelegram(about, input_frame, false, &addresses, &match, &out_telegram);
+
+    // Generate output
+    string hr, fields, json;
+    vector<string> envs, more_json, selected_fields;
+    meter->printMeter(&out_telegram, &hr, &fields, '\t', &json, &envs, &more_json, &selected_fields, true);
+
+    // Check parse quality - how much of the content was understood (in bytes)
+    int content_bytes = 0, understood_bytes = 0;
+    out_telegram.analyzeParse(OutputFormat::NONE, &content_bytes, &understood_bytes);
+
+    if (!handled)
+    {
+        // Add error info to JSON
+        if (!json.empty() && json.back() == '}')
+        {
+            json.pop_back();
+        }
+
+        if (out_telegram.decryption_failed)
+        {
+            json += ", \"error\": \"decryption failed, please check key\"";
+        }
+        else
+        {
+            string analyze_output = out_telegram.analyzeParse(OutputFormat::PLAIN, &content_bytes, &understood_bytes);
+            json += ", \"error\": \"decoding failed\", \"error_analyze\": \"" + escapeJsonString(analyze_output) + "\"";
+        }
+
+        json += ", \"telegram\": \"" + telegram_hex + "\"";
+        json += "}";
+    }
+    else if (content_bytes > 0 && understood_bytes < content_bytes)
+    {
+        // Telegram was handled but not fully understood - add warning with byte counts
+        if (!json.empty() && json.back() == '}')
+        {
+            json.pop_back();
+            json += ", \"warning\": \"telegram only partially decoded (" +
+                    to_string(understood_bytes) + " of " + to_string(content_bytes) + " bytes)\"";
+            json += ", \"telegram\": \"" + telegram_hex + "\"}";
+        }
+    }
+
+    return json;
+}

--- a/src/decode.h
+++ b/src/decode.h
@@ -1,0 +1,45 @@
+/*
+ Copyright (C) 2024-2026 Fredrik Öhrström (gpl-3.0-or-later)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DECODE_H
+#define DECODE_H
+
+#include"meters.h"
+
+#include<map>
+#include<memory>
+#include<string>
+
+struct CachedMeter
+{
+    std::shared_ptr<Meter> meter;
+    std::string key;
+};
+
+struct DecoderSession
+{
+    // Cache meters by meter_id - driver is remembered in meter->driverName()
+    std::map<std::string, CachedMeter> meter_cache;
+};
+
+// Decode a single JSON/XMQ/XML line request. Returns JSON result string.
+std::string decodeLine(DecoderSession &session, const std::string &line);
+
+// Simple JSON string escaper
+std::string escapeJsonString(const std::string &input);
+
+#endif

--- a/src/decoding_server.cc
+++ b/src/decoding_server.cc
@@ -1,0 +1,275 @@
+/*
+ Copyright (C) 2026 Fredrik Öhrström (gpl-3.0-or-later)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include"decoding_server.h"
+#include"decode.h"
+#include"drivers.h"
+#include"util.h"
+
+#include<errno.h>
+#include<fcntl.h>
+#include<map>
+#include<signal.h>
+#include<string.h>
+#include<string>
+#include<unistd.h>
+
+#include<sys/types.h>
+#include<sys/socket.h>
+#include<netinet/in.h>
+#include<arpa/inet.h>
+
+using namespace std;
+
+static volatile sig_atomic_t shutdown_requested_ = 0;
+
+static void shutdownHandler(int signo)
+{
+    shutdown_requested_ = 1;
+}
+
+// Remove newlines and leading whitespace to compact pretty-printed JSON
+// into a single line suitable for the JSON Lines protocol.
+static string compactJson(const string &json)
+{
+    string out;
+    out.reserve(json.size());
+    bool in_string = false;
+    bool escape = false;
+    for (char c : json)
+    {
+        if (escape)
+        {
+            out += c;
+            escape = false;
+            continue;
+        }
+        if (c == '\\' && in_string)
+        {
+            out += c;
+            escape = true;
+            continue;
+        }
+        if (c == '"')
+        {
+            in_string = !in_string;
+            out += c;
+            continue;
+        }
+        if (!in_string)
+        {
+            if (c == '\n' || c == '\r') continue;
+            // Collapse runs of whitespace (indentation) to nothing
+            // between structural tokens.
+            if (c == ' ' || c == '\t') continue;
+        }
+        out += c;
+    }
+    return out;
+}
+
+struct ClientState
+{
+    string line_buffer;
+    string write_buffer;
+    DecoderSession session;
+};
+
+static bool setNonBlocking(int fd)
+{
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags == -1) return false;
+    return fcntl(fd, F_SETFL, flags | O_NONBLOCK) != -1;
+}
+
+int startDecodingServer(int port)
+{
+    loadAllBuiltinDrivers();
+
+    // Install signal handlers for graceful shutdown
+    struct sigaction sa;
+    sa.sa_handler = shutdownHandler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGTERM, &sa, NULL);
+    sigaction(SIGINT, &sa, NULL);
+
+    // Ignore SIGPIPE so writing to a disconnected client returns EPIPE
+    signal(SIGPIPE, SIG_IGN);
+
+    // Create IPv6 dual-stack socket
+    int server_fd = socket(AF_INET6, SOCK_STREAM, 0);
+    if (server_fd < 0)
+    {
+        error("(decodingserver) failed to create socket: %s\n", strerror(errno));
+    }
+
+    int opt = 1;
+    setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    // Allow both IPv4 and IPv6 connections
+    int no = 0;
+    setsockopt(server_fd, IPPROTO_IPV6, IPV6_V6ONLY, &no, sizeof(no));
+
+    struct sockaddr_in6 addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin6_family = AF_INET6;
+    addr.sin6_addr = in6addr_any;
+    addr.sin6_port = htons(port);
+
+    if (::bind(server_fd, (struct sockaddr*)&addr, sizeof(addr)) < 0)
+    {
+        close(server_fd);
+        error("(decodingserver) failed to bind to port %d: %s\n", port, strerror(errno));
+    }
+
+    if (listen(server_fd, 16) < 0)
+    {
+        close(server_fd);
+        error("(decodingserver) failed to listen: %s\n", strerror(errno));
+    }
+
+    if (!setNonBlocking(server_fd))
+    {
+        close(server_fd);
+        error("(decodingserver) failed to set non-blocking: %s\n", strerror(errno));
+    }
+
+    notice("(decodingserver) listening on port %d\n", port);
+
+    map<int, ClientState> clients;
+
+    while (!shutdown_requested_)
+    {
+        fd_set read_fds, write_fds;
+        FD_ZERO(&read_fds);
+        FD_ZERO(&write_fds);
+
+        FD_SET(server_fd, &read_fds);
+        int max_fd = server_fd;
+
+        for (auto &kv : clients)
+        {
+            int fd = kv.first;
+            FD_SET(fd, &read_fds);
+            if (!kv.second.write_buffer.empty())
+            {
+                FD_SET(fd, &write_fds);
+            }
+            if (fd > max_fd) max_fd = fd;
+        }
+
+        struct timeval tv;
+        tv.tv_sec = 1;
+        tv.tv_usec = 0;
+
+        int ready = select(max_fd + 1, &read_fds, &write_fds, NULL, &tv);
+        if (ready < 0)
+        {
+            if (errno == EINTR) continue;
+            break;
+        }
+        if (ready == 0) continue;
+
+        // Accept new connections
+        if (FD_ISSET(server_fd, &read_fds))
+        {
+            struct sockaddr_in6 client_addr;
+            socklen_t client_len = sizeof(client_addr);
+            int client_fd = accept(server_fd, (struct sockaddr*)&client_addr, &client_len);
+            if (client_fd >= 0)
+            {
+                setNonBlocking(client_fd);
+                clients[client_fd] = ClientState();
+                debug("(decodingserver) client connected fd=%d\n", client_fd);
+            }
+        }
+
+        // Process existing clients
+        vector<int> to_remove;
+
+        for (auto &kv : clients)
+        {
+            int fd = kv.first;
+            ClientState &cs = kv.second;
+
+            // Handle writes first
+            if (FD_ISSET(fd, &write_fds) && !cs.write_buffer.empty())
+            {
+                ssize_t n = write(fd, cs.write_buffer.data(), cs.write_buffer.size());
+                if (n > 0)
+                {
+                    cs.write_buffer.erase(0, n);
+                }
+                else if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
+                {
+                    to_remove.push_back(fd);
+                    continue;
+                }
+            }
+
+            // Handle reads
+            if (FD_ISSET(fd, &read_fds))
+            {
+                char buf[4096];
+                ssize_t n = read(fd, buf, sizeof(buf));
+                if (n <= 0)
+                {
+                    // Connection closed or error
+                    to_remove.push_back(fd);
+                    continue;
+                }
+
+                for (ssize_t i = 0; i < n; i++)
+                {
+                    char c = buf[i];
+                    if (c == '\n')
+                    {
+                        if (!cs.line_buffer.empty())
+                        {
+                            string result = compactJson(decodeLine(cs.session, cs.line_buffer));
+                            result += "\n";
+                            cs.write_buffer += result;
+                            cs.line_buffer.clear();
+                        }
+                    }
+                    else if (c != '\r')
+                    {
+                        cs.line_buffer += c;
+                    }
+                }
+            }
+        }
+
+        for (int fd : to_remove)
+        {
+            debug("(decodingserver) client disconnected fd=%d\n", fd);
+            close(fd);
+            clients.erase(fd);
+        }
+    }
+
+    // Clean shutdown
+    for (auto &kv : clients)
+    {
+        close(kv.first);
+    }
+    close(server_fd);
+
+    notice("(decodingserver) stopped\n");
+    return 0;
+}

--- a/src/decoding_server.h
+++ b/src/decoding_server.h
@@ -1,0 +1,25 @@
+/*
+ Copyright (C) 2026 Fredrik Öhrström (gpl-3.0-or-later)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DECODING_SERVER_H
+#define DECODING_SERVER_H
+
+// Start a TCP decoding server on the given port.
+// Blocks until shutdown signal received. Returns 0 on success.
+int startDecodingServer(int port);
+
+#endif

--- a/src/main.cc
+++ b/src/main.cc
@@ -18,6 +18,7 @@
 #include"bus.h"
 #include"cmdline.h"
 #include"config.h"
+#include"decoding_server.h"
 #include"drivers.h"
 #include"meters.h"
 #include"printer.h"
@@ -164,6 +165,11 @@ provided you with this binary. Read the full license for all details.
 #include"short_manual.h"
         puts(short_manual);
         exit(0);
+    }
+
+    if (config->decoding_server_port > 0)
+    {
+        exit(startDecodingServer(config->decoding_server_port));
     }
 
     if (config->daemon)

--- a/src/wmbus_xmqtty.c
+++ b/src/wmbus_xmqtty.c
@@ -21,48 +21,16 @@
 #include"serial.h"
 #include"meters.h"
 #include"drivers.h"
-#include"xmq.h"
+#include"decode.h"
 
 #include<assert.h>
 #include<pthread.h>
 #include<semaphore.h>
 #include<errno.h>
 #include<unistd.h>
-#include<sstream>
 #include<string.h>
-#include<iomanip>
-#include<map>
 
 using namespace std;
-
-// Simple JSON string escaper
-static string escapeJsonString(const string &input)
-{
-    ostringstream ss;
-    for (char c : input)
-    {
-        switch (c)
-        {
-        case '"':  ss << "\\\""; break;
-        case '\\': ss << "\\\\"; break;
-        case '\b': ss << "\\b"; break;
-        case '\f': ss << "\\f"; break;
-        case '\n': ss << "\\n"; break;
-        case '\r': ss << "\\r"; break;
-        case '\t': ss << "\\t"; break;
-        default:
-            if ('\x00' <= c && c <= '\x1f')
-            {
-                ss << "\\u" << hex << setw(4) << setfill('0') << (int)c;
-            }
-            else
-            {
-                ss << c;
-            }
-        }
-    }
-    return ss.str();
-}
 
 struct WMBusXmqTTY : public virtual BusDeviceCommonImplementation
 {
@@ -85,21 +53,10 @@ struct WMBusXmqTTY : public virtual BusDeviceCommonImplementation
 
 private:
     void processLine(const string &line);
-    void outputError(const string &error_msg, const string &telegram_hex);
-    void outputResult(const string &json_result);
 
     string line_buffer_;
     LinkModeSet link_modes_;
-
-    // Cache entry: meter + last used key (to detect key changes)
-    struct CachedMeter
-    {
-        shared_ptr<Meter> meter;
-        string key;
-    };
-
-    // Cache meters by meter_id - driver is remembered in meter->driverName()
-    map<string, CachedMeter> meter_cache_;
+    DecoderSession session_;
 };
 
 shared_ptr<BusDevice> openXmqTTY(Detected detected,
@@ -158,242 +115,11 @@ bool WMBusXmqTTY::deviceSetLinkModes(LinkModeSet lms)
     return true;
 }
 
-void WMBusXmqTTY::outputError(const string &error_msg, const string &telegram_hex)
-{
-    printf("{\"error\": \"%s\"", escapeJsonString(error_msg).c_str());
-    if (!telegram_hex.empty())
-    {
-        printf(", \"telegram\": \"%s\"", telegram_hex.c_str());
-    }
-    printf("}\n");
-    fflush(stdout);
-}
-
-void WMBusXmqTTY::outputResult(const string &json_result)
-{
-    printf("%s\n", json_result.c_str());
-    fflush(stdout);
-}
-
 void WMBusXmqTTY::processLine(const string &line)
 {
-    // Parse JSON input: {"_": "decode", "telegram": "HEX", "key": "HEX", "driver": "auto", "format": "wmbus"}
-    // Parse XMQ  input: decode{telegram=HEX key=HEX driver=auto format=wmbus}
-    // Parse XML  input: <decode><telegram>HEX</telegram><key>HEX</key><driver>auto</driver><format>wmbus</format></decode>
-    XMQDoc *doc = xmqNewDoc();
-    bool ok = xmqParseBufferWithType(doc, line.c_str(), line.c_str()+line.length(), NULL, XMQ_CONTENT_DETECT, 0);
-
-    if (!ok)
-    {
-        string error = xmqDocError(doc);
-        outputError(error, "");
-    }
-
-    string telegram_hex, key_hex, driver_name, format_str;
-
-    const char *telegram_hex_s = xmqGetString(doc, "/decode/telegram");
-    if (!telegram_hex_s)
-    {
-        outputError("missing 'telegram' field in JSON input", "");
-        xmqFreeDoc(doc);
-        return;
-    }
-    telegram_hex = telegram_hex_s;
-
-    // Key is optional - can be empty or "NOKEY"
-    const char *key_hex_s = xmqGetString(doc, "/decode/key");
-    if (key_hex_s == NULL || !strcmp(key_hex_s, "NOKEY")) key_hex = "";
-    else key_hex = key_hex_s;
-
-    // Driver is optional - defaults to "auto"
-    const char *driver_name_s = xmqGetString(doc, "/decode/driver");
-    if (driver_name_s == NULL) driver_name = "auto";
-    else driver_name = driver_name_s;
-
-    // Format is optional - "wmbus", "mbus", or auto-detect if not specified
-    const char *format_s = xmqGetString(doc, "/decode/format");
-    if (format_s == NULL) format_str = "";
-    else format_str = format_s;
-
-    xmqFreeDoc(doc);
-
-    // Convert hex to binary
-    vector<uchar> input_frame;
-    bool invalid_hex = false;
-    if (!isHexStringStrict(telegram_hex, &invalid_hex))
-    {
-        outputError("invalid hex string in 'telegram' field", telegram_hex);
-        return;
-    }
-    ok = hex2bin(telegram_hex, &input_frame);
-    if (!ok)
-    {
-        outputError("failed to decode hex telegram", telegram_hex);
-        return;
-    }
-
-    // Determine frame type
-    size_t frame_length;
-    int payload_len, payload_offset;
-    FrameType frame_type;
-
-    if (format_str == "wmbus")
-    {
-        // Explicit WMBUS - skip detection
-        frame_type = FrameType::WMBUS;
-    }
-    else if (format_str == "mbus")
-    {
-        // Explicit MBUS - skip detection
-        frame_type = FrameType::MBUS;
-        if (FullFrame == checkMBusFrame(input_frame, &frame_length, &payload_len, &payload_offset, true))
-        {
-            // Remove checksum and end marker for MBUS
-            while (((size_t)payload_len) < input_frame.size()) input_frame.pop_back();
-        }
-    }
-    else
-    {
-        // Auto-detect: try WMBUS first (more common), fall back to MBUS
-        if (FullFrame == checkWMBusFrame(input_frame, &frame_length, &payload_len, &payload_offset, true))
-        {
-            frame_type = FrameType::WMBUS;
-        }
-        else if (FullFrame == checkMBusFrame(input_frame, &frame_length, &payload_len, &payload_offset, true))
-        {
-            frame_type = FrameType::MBUS;
-            // Remove checksum and end marker for MBUS
-            while (((size_t)payload_len) < input_frame.size()) input_frame.pop_back();
-        }
-        else
-        {
-            // Neither detected - try as WMBUS (let parser handle error)
-            frame_type = FrameType::WMBUS;
-        }
-    }
-
-    // Parse telegram header
-    Telegram t;
-    AboutTelegram about("", 0, LinkMode::UNKNOWN, frame_type);
-    t.about = about;
-
-    ok = t.parseHeader(input_frame);
-    if (!ok)
-    {
-        outputError("failed to parse telegram header", telegram_hex);
-        return;
-    }
-
-    // Get meter ID from telegram
-    string meter_id = t.addresses.back().id;
-
-    // Try to find meter in cache by meter_id
-    shared_ptr<Meter> meter;
-    auto it = meter_cache_.find(meter_id);
-
-    bool need_new_meter = (it == meter_cache_.end());
-
-    if (!need_new_meter)
-    {
-        // Found cached meter - check if key changed
-        if (it->second.key == key_hex)
-        {
-            // Same key, reuse meter (driver is already resolved)
-            meter = it->second.meter;
-        }
-        else
-        {
-            // Key changed, need to create new meter
-            need_new_meter = true;
-        }
-    }
-
-    if (need_new_meter)
-    {
-        // Find best driver if auto (only when creating new meter)
-        if (driver_name == "auto")
-        {
-            DriverInfo auto_di = pickMeterDriver(&t);
-            if (auto_di.name().str() != "")
-            {
-                driver_name = auto_di.name().str();
-            }
-            else
-            {
-                driver_name = "unknown";
-            }
-        }
-
-        // Create new meter and cache it
-        MeterInfo mi;
-        mi.key = key_hex;
-        mi.address_expressions.clear();
-        mi.address_expressions.push_back(AddressExpression(t.addresses.back()));
-        mi.identity_mode = IdentityMode::ID;
-        mi.driver_name = DriverName(driver_name);
-        mi.poll_interval = 1000*1000*1000;  // Fake a high value to silence warning
-
-        meter = createMeter(&mi);
-        if (meter == NULL)
-        {
-            outputError("failed to create meter", telegram_hex);
-            return;
-        }
-
-        CachedMeter cached;
-        cached.meter = meter;
-        cached.key = key_hex;
-        meter_cache_[meter_id] = cached;
-    }
-
-    bool match = false;
-    vector<Address> addresses;
-    Telegram out_telegram;
-    bool handled = meter->handleTelegram(about, input_frame, false, &addresses, &match, &out_telegram);
-
-    // Generate output
-    string hr, fields, json;
-    vector<string> envs, more_json, selected_fields;
-    meter->printMeter(&out_telegram, &hr, &fields, '\t', &json, &envs, &more_json, &selected_fields, true);
-
-    // Check parse quality - how much of the content was understood (in bytes)
-    int content_bytes = 0, understood_bytes = 0;
-    out_telegram.analyzeParse(OutputFormat::NONE, &content_bytes, &understood_bytes);
-
-    if (!handled)
-    {
-        // Add error info to JSON
-        if (!json.empty() && json.back() == '}')
-        {
-            json.pop_back();
-        }
-
-        if (out_telegram.decryption_failed)
-        {
-            json += ", \"error\": \"decryption failed, please check key\"";
-        }
-        else
-        {
-            string analyze_output = out_telegram.analyzeParse(OutputFormat::PLAIN, &content_bytes, &understood_bytes);
-            json += ", \"error\": \"decoding failed\", \"error_analyze\": \"" + escapeJsonString(analyze_output) + "\"";
-        }
-
-        json += ", \"telegram\": \"" + telegram_hex + "\"";
-        json += "}";
-    }
-    else if (content_bytes > 0 && understood_bytes < content_bytes)
-    {
-        // Telegram was handled but not fully understood - add warning with byte counts
-        if (!json.empty() && json.back() == '}')
-        {
-            json.pop_back();
-            json += ", \"warning\": \"telegram only partially decoded (" +
-                    to_string(understood_bytes) + " of " + to_string(content_bytes) + " bytes)\"";
-            json += ", \"telegram\": \"" + telegram_hex + "\"}";
-        }
-    }
-
-    outputResult(json);
+    string result = decodeLine(session_, line);
+    printf("%s\n", result.c_str());
+    fflush(stdout);
 }
 
 void WMBusXmqTTY::processSerialData()


### PR DESCRIPTION
## Summary

- Extract decode logic from `wmbus_xmqtty.c` into a reusable `decode.h`/`decode.cc` module shared by both `stdin:jsonl` and the new TCP server
- Add `--decodingserver=PORT` flag that starts a single-threaded `select()`-based TCP server accepting JSON, XMQ, or XML decode requests (one per line) and returning compact JSON Lines responses
- Each client gets its own `DecoderSession` with independent meter caching, non-blocking I/O, IPv6 dual-stack socket, and graceful shutdown on SIGTERM/SIGINT
- Existing `stdin:jsonl` behavior is unchanged

## New files

| File | Description |
|------|-------------|
| `src/decode.h` / `src/decode.cc` | Shared decode module (extracted from `wmbus_xmqtty.c`) |
| `src/decoding_server.h` / `src/decoding_server.cc` | TCP server implementation |
| `examples/decoding_client.py` | Sample Python client (one-shot and persistent session) |
| `Dockerfile.dev` | Alpine-based build/test environment |

## Usage

```bash
wmbusmeters --decodingserver=12345
```

```bash
echo '{"_":"decode","telegram":"1844AE4C4455223368077A55000000041389E20100023B0000","key":"NOKEY","driver":"iperl"}' | nc localhost 12345
# → {"_":"telegram","media":"water","meter":"iperl","name":"","id":"33225544","max_flow_m3h":0,"total_m3":123.529,...}
```

## Test plan

- [x] Docker build passes (`make && make test` — all existing tests pass)
- [x] Manual server test: single telegram decode returns correct JSON
- [x] Error handling: malformed JSON, missing fields return JSON error responses
- [x] Persistent connections: multiple requests over one TCP session work correctly
- [x] Python client: both one-shot and session modes verified against server

🤖 Generated with [Claude Code](https://claude.com/claude-code)