### PR TITLE
Add support for Diehl Type 173 variant

### DIFF
--- a/src/driver_evo868.cc
+++ b/src/driver_evo868.cc
@@ -34,6 +34,7 @@ namespace
         di.addMVT(MANUFACTURER_MAD,  0x06,  0x50);
         di.addMVT(MANUFACTURER_MAD,  0x07,  0x50);
         di.addMVT(MANUFACTURER_MAD,  0x16,  0x50);
+        di.addMVT(MANUFACTURER_DME,  0x07,  0x63); // Diehl Type 173 variant reusing evo868 payload
 
     });
 


### PR DESCRIPTION
This change adds the support for (DME) DIEHL Metering, Germany (0x11a5) type: Water meter (0x07) ver: 0x63. Issue #1533 

I tested it and it works just fine:

```
{
  "_": "telegram",
  "media": "water",
  "meter": "evo868",
  "name": "watermeter",
  "id": "11111118",
  "consumption_at_history_1_m3": 4.674,
  "consumption_at_set_date_m3": 0.2,
  "history_1_date": "1970-01-01",
  "total_m3": 6.592,
  "current_status": "OK",
  "set_date": "2025-12-31",
  "timestamp": "2026-02-04T19:36:59Z",
  "device": "rtlwmbus[00000001]",
  "rssi_dbm": 141
}
```
