### PR TITLE
Fix hydroclima driver for firmware version 0x85

### DIFF
--- a/tests/test_json_stdin.sh
+++ b/tests/test_json_stdin.sh
@@ -157,7 +157,7 @@ fi
 TESTNAME="Test json on stdin with partial decode warning"
 
 cat > $TEST/test_expected_unsorted.txt <<EOF
-{"_":"telegram","media":"heat cost allocation","meter":"hydroclima","name":"","id":"68036198","current_consumption_hca":0,"average_ambient_temperature_c":18.66,"max_ambient_temperature_c":47.51,"average_ambient_temperature_last_month_c":15.78,"average_heater_temperature_last_month_c":17.47,"warning":"telegram only partially decoded (26 of 51 bytes)","telegram":"2e44b0099861036853087a000020002F2F036E0000000F100043106A7D2C4A078F12202CB1242A06D3062100210000","timestamp":"1111-11-11T11:11:11Z"}
+{"_":"telegram","media":"heat cost allocation","meter":"hydroclima","name":"","id":"68036198","current_consumption_hca":0,"average_ambient_temperature_c":18.66,"max_ambient_temperature_c":47.51,"average_ambient_temperature_last_month_c":15.78,"average_heater_temperature_last_month_c":17.47,"timestamp":"1111-11-11T11:11:11Z"}
 EOF
 
 jq --sort-keys . $TEST/test_expected_unsorted.txt > $TEST/test_expected.txt


### PR DESCRIPTION
## Summary

- Add auto-detection for BMeters HydroClima firmware version **0x85** (`addMVT(MANUFACTURER_BMP, 0x08, 0x85)`)
- Complete decoding of frame 0x11 (v0x85) manufacturer-specific data per **PAPP-HARF2** specification (KA1 structure, 47 bytes)
- Add DIF/VIF extractors for `set_date` and `consumption_at_set_date` (storage nr 1)
- Fix per-byte deduplication in `analyzeParse` to prevent false "partially decoded" warnings for processContent drivers
- Add two encrypted test cases for v0x85

## Problem

Version 0x85 HydroClima 2 ITN devices (manufacturer BMP, type 0x08) were not auto-detected because only version 0x53 was registered. When forced via `driver=hydroclima`, the driver misinterpreted the frame 0x11 data layout — frames 0x10 and 0x11 diverge at **byte 7** (after DAT), not byte 15 as originally coded.

## Changes

### `src/driver_hydroclima.cc`

Frame 0x10 (v0x53, 24B mfct) and frame 0x11 (v0x85, 47B mfct) now have separate parsing paths diverging at byte 7.

**Frame 0x11 decodes the full KA1 structure:**

| Offset | Field | Description |
|--------|-------|-------------|
| 0 | Frame ID | 0x11 |
| 1–2 | STS | Status word |
| 3–4 | TIM | Current time |
| 5–6 | DAT | Current date |
| 7–8 | DOP | Housing open event date |
| 9–10 | TKA | Average heater temperature (current period) |
| 11–12 | TOA | Average ambient temperature (current period) |
| 13–14 | TMH1 | Max temperature (previous period) |
| 15–16 | TMHD1 | Date of max temperature |
| 17–18 | TKA1 | Average heater temperature (previous period) |
| 19–20 | TOA1 | Average ambient temperature (previous period) |
| 21–28 | CNI1–4 | Consumption history (4 × 2B, HCA) |
| 29–34 | TONI1–3 | Ambient temperature history (3 × 2B, 0x8000 = no data) |
| 35–43 | TK counts | Temperature bin counters (3 × 3B) |
| 44–46 | U | Total consumption all periods (3B, /10 = HCA) |

**New JSON fields** for v0x85: `average_heater_temperature`, `consumption_at_set_date_1`–`4`, `ambient_temperature_at_set_date_1`–`3`, `total_consumption`, `set_date`, `consumption_at_set_date`.

### `src/wmbus.cc`

Fixed `analyzeParse` byte counting: uses per-byte tracking vectors to deduplicate overlapping explanations from DIF/VIF parse + processContent. Protocol-marked bytes (like the 0F DIF) are excluded from content count. This eliminates false "partially decoded" warnings for all processContent drivers (hydroclima, hydrodigit, etc.).

### `tests/test_json_stdin.sh`

Updated expected output for hydroclima stdin test — removed the now-incorrect `warning` field (consequence of the wmbus.cc fix).

## Verification

Tested on **52 real-world v0x85 meters** — all decode correctly with plausible values. Backward compatibility with v0x53 confirmed.

## Test plan

- [x] `make` compiles without warnings
- [x] `./test.sh` — all 119 tests pass
- [x] Existing v0x53 test cases unchanged and passing
- [x] Two v0x85 test cases: HCA85 (full data) + HCA85B (with no-data markers in TONI fields)
- [x] Manual decode of encrypted v0x85 telegrams returns correct values