### PR TITLE
Fix the scaling of the measured units used in the Q walk-by subtelegram.

### DIFF
--- a/src/driver_qheat.cc
+++ b/src/driver_qheat.cc
@@ -196,11 +196,12 @@ namespace
         if (it != t->dv_entries.end()) {
             DVEntry entry = it->second.second;
             if (entry.value.length() == 53 * 2) {
-                qdsExtractWalkByField(t, this, entry, 24, 8, "0C05", "total_energy_consumption", Quantity::Energy);
+                string scale = entry.value.substr(18, 2);
+                qdsExtractWalkByField(t, this, entry, 24, 8, "0C" + scale, "total_energy_consumption", Quantity::Energy);
                 qdsExtractWalkByField(t, this, entry, 32, 4, "426C", "last_year_date", Quantity::Text);
-                qdsExtractWalkByField(t, this, entry, 36, 8, "4C05", "last_year_energy_consumption", Quantity::Energy);
+                qdsExtractWalkByField(t, this, entry, 36, 8, "4C" + scale, "last_year_energy_consumption", Quantity::Energy);
                 qdsExtractWalkByField(t, this, entry, 44, 4, "C2086C", "last_month_date", Quantity::Text);
-                qdsExtractWalkByField(t, this, entry, 48, 8, "CC0805", "last_month_energy_consumption", Quantity::Energy);
+                qdsExtractWalkByField(t, this, entry, 48, 8, "CC08" + scale, "last_month_energy_consumption", Quantity::Energy);
             }
         }
     }

--- a/src/driver_qwater.cc
+++ b/src/driver_qwater.cc
@@ -153,11 +153,12 @@ void Driver::processContent(Telegram *t) {
     if (entry.value.length() != 53 * 2) {
         return;
     }
-    qdsExtractWalkByField(t, this, entry, 24, 8, "0C13", "total", Quantity::Volume);
+    string scale = entry.value.substr(18, 2);
+    qdsExtractWalkByField(t, this, entry, 24, 8, "0C" + scale, "total", Quantity::Volume);
     qdsExtractWalkByField(t, this, entry, 32, 4, "426C", "due", Quantity::PointInTime);
-    qdsExtractWalkByField(t, this, entry, 36, 8, "4C13", "due_date", Quantity::Volume);
+    qdsExtractWalkByField(t, this, entry, 36, 8, "4C" + scale, "due_date", Quantity::Volume);
     qdsExtractWalkByField(t, this, entry, 44, 4, "C2086C", "due_17", Quantity::PointInTime);
-    qdsExtractWalkByField(t, this, entry, 48, 8, "CC0813", "due_17_date", Quantity::Volume);
+    qdsExtractWalkByField(t, this, entry, 48, 8, "CC08" + scale, "due_17_date", Quantity::Volume);
 }
 
 // Test: MyQWater qwater 12353648 NOKEY


### PR DESCRIPTION
The energy/volume scale is encoded in bytes[19:18] of subtelegram.