### PR TITLE
Added support for IMST iU893A-XL

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine AS build
 RUN apk add --no-cache alpine-sdk gcc linux-headers libxml2-dev libxslt-dev cmake libusb-dev bash samurai
 
 RUN git clone --depth 1 https://github.com/steve-m/librtlsdr.git && \
-    git clone --depth 1 https://github.com/icho911/wmbusmeters.git && \
+    git clone --depth 1 https://github.com/wmbusmeters/wmbusmeters.git && \
     git clone --depth 1 https://github.com/weetmuts/rtl-wmbus.git && \
     git clone --depth 1 https://github.com/merbanan/rtl_433.git && \
     git clone --depth 1 https://github.com/ED6E0F17/rtl_reset.git && \


### PR DESCRIPTION
This change adds support for newly released USB-Stick IMST iU893A-XL. Only added the new mode_type.

I tested it and can now receive telegrams. The stick is recognized as iU891A.