### PR TITLE
Update Dockerfile - add ca-certificates

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR /xmq
 RUN ./configure && make -j`nproc`
 
 FROM alpine AS builder
-RUN apk add --no-cache mosquitto-clients libstdc++ curl libusb libxml2
+RUN apk add --no-cache mosquitto-clients libstdc++ curl libusb libxml2 ca-certificates 
 WORKDIR /wmbusmeters
 COPY --from=build /librtlsdr/build/src/librtlsdr.so.* /usr/lib/
 COPY --from=build /librtlsdr/rtl-sdr.rules /usr/lib/udev/rules.d/rtl-sdr.rules


### PR DESCRIPTION
Fix SSL/TLS certificate verification failure in Alpine-based Docker image


### Problem
Users running mosquitto_sub inside the Docker container (Alpine Linux v3.21) to connect to external MQTT brokers over SSL/TLS (port 8883) encounter:

```
OpenSSL Error[0]: error:0A000086:SSL routines::certificate verify failed
Error: Protocol error
```
This occurs specifically with Let's Encrypt certificates (ISRG Root X1 chain), despite working fine from the host system. OpenSSL s_client handshake succeeds (Verify return code: 0 (ok)), confirming the broker cert chain is valid, but mosquitto_sub --capath /etc/ssl/certs fails due to incomplete CA bundle.

### Root Cause
The Alpine image has ca-certificates-bundle installed but lacks the full ca-certificates package and post-install update-ca-certificates step. This results in an incomplete or outdated CA store, missing the ISRG Root X1 root certificate needed for Let's Encrypt verification. Common issue in minimal Alpine Docker images