### PR TITLE
amiplus: decode total energy consumption from DIF/VIF 0E03 to avoid bogus totals

### DIFF
--- a/src/driver_amiplus.cc
+++ b/src/driver_amiplus.cc
@@ -53,7 +53,7 @@ namespace
             VifScaling::Auto, DifSignedness::Signed,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
-            .set(VIFRange::AnyEnergyVIF)
+            .set(DifVifKey("0E03"))
             );
 
         addNumericFieldWithExtractor(


### PR DESCRIPTION
## Summary

This PR makes `amiplus` decode `total_energy_consumption_kwh` from a strict key match (`DifVifKey("0E03")`) instead of a broad `AnyEnergyVIF` matcher.

The change fixes intermittent mis-decoding of total energy consumption (e.g. millions/billions kWh) seen on real Apator/AMI+ telegrams.


## Problem

For my meter `id=00320787` (`amiplus` driver, support added https://github.com/wmbusmeters/wmbusmeters/pull/1367), decoded totals alternated between correct values (~`7436.xxx` kWh) and clearly wrong values such as:

- `393153731.563008`
- `12138361.944444`
- `8665487929.722221`

Example from captured log:

Correct:

```text
telegram=|3E44B6108707320001027A020008052F2F_0C7830253390204B2968336015660E036669430700000E833C9265010000000B2B5702000BAB3C0000002F2F2F2F|+132
{"_":"telegram",...,"total_energy_consumption_kwh":7436.965,...}
```

Wrong:

```text
telegram=|3E44B6108707320001027A020008052F2F_0C783025339022493D6A316217640E036769430700000E833C9265010000000B2B5702000BAB3C0000002F2F2F2F|+141
{"_":"telegram",...,"total_energy_consumption_kwh":393153731.563008,...}
```

## Root cause

`src/driver_amiplus.cc` previously used:

```cpp
.set(MeasurementType::Instantaneous)
.set(VIFRange::AnyEnergyVIF)
```

`AnyEnergyVIF` can match multiple energy-coded fields (`EnergyWh`, `EnergyMJ`, `EnergyMWh`, `EnergyGJ`) in mixed frame layouts. In bad frames this bound `total_energy_consumption` to the wrong field.

## Why `0E03` is correct

The protocol description from my grid operator Linz Netz states the following regarding wireless M-Bus spec (unfortunately only available in German):

https://www.linznetz.at/media/linz_netz_website/netz_dokumente/Beschreibung-Wireless_M-Bus-Schnittstelle.pdf

- Page 6 (`MBUS-Daten`):
  - `1.8.0 0x0E 03 ... Zählerstand Bezug Wirkenergie`
  - `2.8.0 0x0E 0x83 0x3C ... Zählerstand Lieferung Wirkenergie`
- Page 9 (`Beispiel (6/6)`):
  - `0x0E 0x03 ... 18561 Wh 1.8.0`
  - `0x0E 0x83 0x3C ... 16604 Wh 2.8.0`

Parser-level corroboration in wmbusmeters core:

- `src/dvparser.cc`: `0xE` data field => `12 digit BCD`
- `src/dvparser.h`: `VIFRange::EnergyWh` covers `0x00..0x07` (incl. `0x03`)
- `src/wmbus.cc`: DIF function bits `0x00` => `Instantaneous`

## Change

File: `src/driver_amiplus.cc`

For `total_energy_consumption`:

```cpp
FieldMatcher::build()
  .set(MeasurementType::Instantaneous)
  .set(DifVifKey("0E03"))
```

## Validation

I captures a few telegrams and decoded them.

### Replay before fix

- `51` telegram/json pairs with total
- `33` in correct range (`7000..8000`)
- `18` wrong (`>1e6`)

### Replay after fix


- no wrong decodings
- analyzed totals are only sane `7436.xxx`
- formerly wrong frames no longer emit bogus `total_energy_consumption_kwh`

### Build/tests

- local rebuild succeeded (`make`)
- `make test` passed

## Behavior impact

- prevents absurd total-energy-consumption spikes from wrong energy-field binding
- keeps correct `0E03` frames decoding as expected
- for variants without `0E03`, field may be absent instead of wrong (preferred)

That said, I've only validated with my meter and the tests. Not sure if there could be a negative impact on other meters using the `amiplus` driver. If that is a concern, should we make a (sub-)config for this particular meter?
