### PR TITLE
Add short packet signatures for some Kamstrup meters

### DIFF
--- a/src/wmbus.cc
+++ b/src/wmbus.cc
@@ -4086,6 +4086,18 @@ bool Telegram::findFormatBytesFromKnownMeterSignatures(vector<uchar> *format_byt
         hex2bin("04FF234413523B06FF1B426C61675167023B04138101E7FF0F", format_bytes);
         debug("(wmbus) using hard coded format for hash 0905\n");
     }
+    else if (format_signature == 0x2274)
+    {
+        // Kamstrup EM24 W1
+        hex2bin("040504FB827504853C04FB82F53C01FD17", format_bytes);
+        debug("(wmbus) using hard coded format for hash 2274\n");
+    }
+    else if (format_signature == 0xae5a)
+    {
+        // Kamstrup Multical 303
+        hex2bin("0406041404FF0704FF080259025D023B02FF22026C44064414426C", format_bytes);
+        debug("(wmbus) using hard coded format for hash ae5a\n");
+    }
     else
     {
         ok = false;


### PR DESCRIPTION
The code change feels like a lot of repetition, but it's the way how it's currently done, and I have these meters installed, so here we go. Would it make sense to move this signature -> format mapping to the XMQ definition of meter types?