### PR TITLE
Add compact frame signature 0xae5a for Kamstrup MULTICAL 303

### DIFF
--- a/src/wmbus.cc
+++ b/src/wmbus.cc
@@ -4086,6 +4086,11 @@ bool Telegram::findFormatBytesFromKnownMeterSignatures(vector<uchar> *format_byt
         hex2bin("04FF234413523B06FF1B426C61675167023B04138101E7FF0F", format_bytes);
         debug("(wmbus) using hard coded format for hash 0905\n");
     }
+    else if (format_signature == 0xae5a)
+    {
+        hex2bin("0406041404FF0704FF080259025D023B02FF22026C44064414426C", format_bytes);
+        debug("(wmbus) using hard coded format for hash ae5a\n");
+    }
     else
     {
         ok = false;


### PR DESCRIPTION
## Summary
Add hard coded compact frame format signature `0xae5a` for Kamstrup MULTICAL 303 (kamheat) to `findFormatBytesFromKnownMeterSignatures()`.

## Problem
MC303 meters alternate between full frames (CI=0x78, 83B) and compact frames (CI=0x79, 60B). Compact frames contain only a 2-byte format hash + packed data values without DIF/VIF headers. In live mode, wmbusmeters learns the format from a prior full frame. But in offline mode (stdin:jsonl), compact frames fail with "format signature hash 0xae5a is yet unknown".

## Solution
Add signature `0xae5a` → format `0406041404FF0704FF080259025D023B02FF22026C44064414426C` (12 records: energy, volume, forward/return energy, temperatures, flow, status, date, target energy/volume/date).

## Test results
- Before: 109/125 Kamstrup devices decoded OK (16 compact frames failed)
- After: **123/125 OK** (+14 compact frames now decode)
- 2 remaining failures: different issue (decryption problem, not format signature)

## Files
- `src/wmbus.cc` — +5 lines in `findFormatBytesFromKnownMeterSignatures()`