### PR TITLE
chore: optimize initializer

### DIFF
--- a/src/wmbus.cc
+++ b/src/wmbus.cc
@@ -217,19 +217,12 @@ struct Manufacturer {
     }
 };
 
-vector<Manufacturer> manufacturers_;
+const vector<Manufacturer> manufacturers_ = {
+    #define X(key,code,name) Manufacturer(#key, code, name),
+    LIST_OF_MANUFACTURERS
+    #undef X
+};
 
-struct Initializer { Initializer(); };
-
-static Initializer initializser_;
-
-Initializer::Initializer() {
-
-#define X(key,code,name) manufacturers_.push_back(Manufacturer(#key,code,name));
-LIST_OF_MANUFACTURERS
-#undef X
-
-}
 
 void Telegram::addAddressMfctFirst(const vector<uchar>::iterator &pos)
 {


### PR DESCRIPTION
Instead of filling the vector with strings on initialization, we use the preprocessor to prefill the vector at compile time.