### PR TITLE
chore: remove redundant isDebugEnabled calls

### DIFF
--- a/src/formula.cc
+++ b/src/formula.cc
@@ -87,14 +87,11 @@ double NumericFormulaAddition::calculate(SIUnit to_siunit)
     double result {};
     v_siunit.convertTo(v, to_siunit, &result);
 
-    if (isDebugEnabled())
-    {
-        debug("(formula) ADD %g (%s) %g (%s) --> %g %s --> %g %s\n",
-              l, left_->siunit().info().c_str(),
-              r, right_->siunit().info().c_str(),
-              v, v_siunit.info().c_str(),
-              result, siunit().info().c_str());
-    }
+    debug("(formula) ADD %g (%s) %g (%s) --> %g %s --> %g %s\n",
+            l, left_->siunit().info().c_str(),
+            r, right_->siunit().info().c_str(),
+            v, v_siunit.info().c_str(),
+            result, siunit().info().c_str());
 
     return result;
 }
@@ -111,14 +108,11 @@ double NumericFormulaSubtraction::calculate(SIUnit to_siunit)
     double result {};
     v_siunit.convertTo(v, to_siunit, &result);
 
-    if (isDebugEnabled())
-    {
-        debug("(formula) SUB %g (%s) %g (%s) --> %g %s --> %g %s\n",
-              l, left_->siunit().info().c_str(),
-              r, right_->siunit().info().c_str(),
-              v, v_siunit.info().c_str(),
-              result, siunit().info().c_str());
-    }
+    debug("(formula) SUB %g (%s) %g (%s) --> %g %s --> %g %s\n",
+            l, left_->siunit().info().c_str(),
+            r, right_->siunit().info().c_str(),
+            v, v_siunit.info().c_str(),
+            result, siunit().info().c_str());
 
     return result;
 }
@@ -131,14 +125,12 @@ double NumericFormulaMultiplication::calculate(SIUnit to_siunit)
     double v {};
     siunit().convertTo(m, to_siunit, &v);
 
-    if (isDebugEnabled())
-    {
-        debug("(formula) MUL %g (%s) %g (%s) --> %g --> %g %s\n",
-              l, left_->siunit().info().c_str(),
-              r, right_->siunit().info().c_str(),
-              m,
-              v, to_siunit.info().c_str());
-    }
+    debug("(formula) MUL %g (%s) %g (%s) --> %g --> %g %s\n",
+            l, left_->siunit().info().c_str(),
+            r, right_->siunit().info().c_str(),
+            m,
+            v, to_siunit.info().c_str());
+
     return v;
 }
 
@@ -150,15 +142,12 @@ double NumericFormulaDivision::calculate(SIUnit to_siunit)
     double v {};
     siunit().convertTo(d, to_siunit, &v);
 
-    if (isDebugEnabled())
-    {
-        debug("(formula) DIV %g (%s) %g (%s) --> %g --> %g %s\n",
-              l, left_->siunit().info().c_str(),
-              r, right_->siunit().info().c_str(),
-              d,
-              v,
-              to_siunit.info().c_str());
-    }
+    debug("(formula) DIV %g (%s) %g (%s) --> %g --> %g %s\n",
+            l, left_->siunit().info().c_str(),
+            r, right_->siunit().info().c_str(),
+            d,
+            v,
+            to_siunit.info().c_str());
 
     return v;
 }
@@ -182,14 +171,11 @@ double NumericFormulaSquareRoot::calculate(SIUnit to_siunit)
     double v {};
     siunit().convertTo(s, to_siunit, &v);
 
-    if (isDebugEnabled())
-    {
-        debug("(formula) SQRT %g (%s) --> %g --> %g %s\n",
-              i, inner_->siunit().info().c_str(),
-              s,
-              v,
-              to_siunit.info().c_str());
-    }
+    debug("(formula) SQRT %g (%s) --> %g --> %g %s\n",
+            i, inner_->siunit().info().c_str(),
+            s,
+            v,
+            to_siunit.info().c_str());
     return v;
 }
 
@@ -914,10 +900,8 @@ bool FormulaImplementation::parse(Meter *m, const string &f)
     ok = go();
     if (!ok) return false;
 
-    if (isDebugEnabled())
-    {
-        debug("(formula) %s\n", tree().c_str());
-    }
+    debug("(formula) %s\n", tree().c_str());
+
     return valid_;
 }
 

--- a/src/metermanager.cc
+++ b/src/metermanager.cc
@@ -153,12 +153,8 @@ public:
         // then lets check if there is a template that can create a meter for it.
         if (!handled && !exact_id_match)
         {
-            if (isDebugEnabled())
-            {
-                string idsc = Address::concat(addresses);
-                debug("(meter) no meter handled %s checking %d templates.\n",
-                      idsc.c_str(), meter_templates_.size());
-            }
+            debug("(meter) no meter handled %s checking %d templates.\n",
+                    Address::concat(addresses).c_str(), meter_templates_.size());
             // Not handled, maybe we have a template to create a new meter instance for this telegram?
             Telegram t;
             t.about = about;

--- a/src/meters.cc
+++ b/src/meters.cc
@@ -1164,14 +1164,14 @@ bool MeterCommonImplementation::isTelegramForMeter(Telegram *t, Meter *meter, Me
         driver_name = mi->driver_name.str();
     }
 
-    if (isDebugEnabled())
-    {
+    debug(
+        "(meter) %s: for me? %s in %s\n",
+        name.c_str(),
         // Telegram addresses
-        string t_idsc = Address::concat(t->addresses);
+        Address::concat(t->addresses).c_str(),
         // Meter/MeterInfo address expressions
-        string m_idsc = AddressExpression::concat(address_expressions);
-        debug("(meter) %s: for me? %s in %s\n", name.c_str(), t_idsc.c_str(), m_idsc.c_str());
-    }
+        AddressExpression::concat(address_expressions).c_str()
+    );
 
     bool used_wildcard = false;
     bool match = doesTelegramMatchExpressions(t->addresses,
@@ -1476,11 +1476,7 @@ bool MeterCommonImplementation::handleTelegram(AboutTelegram &about, vector<ucha
                 t.addresses.back().str().c_str());
     }
 
-    if (isDebugEnabled())
-    {
-        string msg = bin2hex(input_frame);
-        debug("(meter) %s %s \"%s\"\n", name().c_str(), t.addresses.back().str().c_str(), msg.c_str());
-    }
+    debug("(meter) %s %s \"%s\"\n", name().c_str(), t.addresses.back().str().c_str(), bin2hex(input_frame).c_str());
 
     // For older meters with manufacturer specific data without a nice 0f dif marker.
     if (force_mfct_index_ != -1)

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -273,18 +273,13 @@ int SerialDeviceImp::receive(vector<uchar> *data)
     }
     data->resize(num_read);
 
-    if (isDebugEnabled())
+    if (expecting_ascii_)
     {
-        if (expecting_ascii_)
-        {
-            string msg = safeString(*data);
-            debug("(serial) received ascii \"%s\"\n", msg.c_str());
-        }
-        else
-        {
-            string msg = bin2hex(*data);
-            debug("(serial) received binary \"%s\"\n", msg.c_str());
-        }
+        debug("(serial) received ascii \"%s\"\n", safeString(*data).c_str());
+    }
+    else
+    {
+        debug("(serial) received binary \"%s\"\n", bin2hex(*data).c_str());
     }
 
     if (close_me) close();
@@ -380,19 +375,13 @@ bool SerialDeviceTTY::send(vector<uchar> &data)
         {
             if (errno==EINTR) continue;
             rc = false;
-            if (isDebugEnabled()) {
-                string msg = bin2hex(data);
-                debug("(serial %s) failed to send \"%s\"\n", device_.c_str(), msg.c_str());
-            }
+            debug("(serial %s) failed to send \"%s\"\n", device_.c_str(), bin2hex(data).c_str());
             goto end;
         }
         if (written == n) break;
     }
 
-    if (isDebugEnabled()) {
-        string msg = bin2hex(data);
-        debug("(serial %s) sent \"%s\"\n", device_.c_str(), msg.c_str());
-    }
+    debug("(serial %s) sent \"%s\"\n", device_.c_str(), bin2hex(data).c_str());
 
     if (signalsInstalled())
     {
@@ -537,10 +526,7 @@ bool SerialDeviceCommand::send(vector<uchar> &data)
         if (written == n) break;
     }
 
-    if (isDebugEnabled()) {
-        string msg = bin2hex(data);
-        debug("(serial %s) sent \"%s\"\n", command_.c_str(), msg.c_str());
-    }
+    debug("(serial %s) sent \"%s\"\n", command_.c_str(), bin2hex(data).c_str());
 
     end:
     return rc;
@@ -846,11 +832,7 @@ bool SerialDeviceSocket::send(vector<uchar> &data)
         }
     }
 
-    if (isDebugEnabled())
-    {
-        string msg = safeString(data);
-        debug("(serialsocket) sent \"%s\"\n", msg.c_str());
-    }
+    debug("(serialsocket) sent \"%s\"\n", safeString(data).c_str());
 
     return true;
 }
@@ -887,10 +869,9 @@ int SerialDeviceSocket::receive(vector<uchar> *data)
     }
     data->resize(num_read);
 
-    if (isDebugEnabled() && num_read > 0)
+    if (num_read != 0)
     {
-        string msg = safeString(*data);
-        debug("(serialsocket) received \"%s\"\n", msg.c_str());
+        debug("(serialsocket) received \"%s\"\n", safeString(*data).c_str());
     }
 
     return num_read;

--- a/src/util.cc
+++ b/src/util.cc
@@ -776,20 +776,12 @@ bool checkIfDirExists(const char *dir)
 
 void debugPayload(const string& intro, vector<uchar> &payload)
 {
-    if (isDebugEnabled())
-    {
-        string msg = bin2hex(payload);
-        debug("%s \"%s\"\n", intro.c_str(), msg.c_str());
-    }
+    debug("%s \"%s\"\n", intro.c_str(), bin2hex(payload).c_str());
 }
 
 void debugPayload(const string& intro, vector<uchar> &payload, vector<uchar>::iterator &pos)
 {
-    if (isDebugEnabled())
-    {
-        string msg = bin2hex(pos, payload.end(), 1024);
-        debug("%s \"%s\"\n", intro.c_str(), msg.c_str());
-    }
+    debug("%s \"%s\"\n", intro.c_str(), bin2hex(pos, payload.end(), 1024).c_str());
 }
 
 void logTelegram(vector<uchar> &original, vector<uchar> &parsed, int header_size, int suffix_size)

--- a/src/wmbus_cul.cc
+++ b/src/wmbus_cul.cc
@@ -293,11 +293,7 @@ FrameStatus WMBusCUL::checkCULFrame(vector<uchar> &data,
 {
     if (data.size() == 0) return PartialFrame;
 
-    if (isDebugEnabled())
-    {
-        string s  = safeString(data);
-        debug("(cul) checkCULFrame \"%s\"\n", s.c_str());
-    }
+    debug("(cul) checkCULFrame \"%s\"\n", safeString(data).c_str());
 
     size_t eolp = 0;
     // Look for end of line
@@ -339,11 +335,7 @@ FrameStatus WMBusCUL::checkCULFrame(vector<uchar> &data,
     // Calculate dBm according to datasheet of CC1101 SWRS061I page 44
     *rssi_dbm = rssi_raw/2 - 74;
 
-    if (isDebugEnabled())
-    {
-        debug("(cul) checkCULFrame RSSI_RAW=%d\n", rssi_raw);
-        debug("(cul) checkCULFrame LQI=%d\n", lqi);
-    }
+    debug("(cul) checkCULFrame RSSI_RAW=%d\n(cul) checkCULFrame LQI=%d\n", rssi_raw, lqi);
 
     if (data[1] == 'Y')
     {

--- a/src/wmbus_rtl433.cc
+++ b/src/wmbus_rtl433.cc
@@ -290,11 +290,7 @@ FrameStatus WMBusRTL433::checkRTL433Frame(vector<uchar> &data,
 
     if (data.size() == 0) return PartialFrame;
 
-    if (isDebugEnabled())
-    {
-        string msg = safeString(data);
-        debug("(rtl433) checkRTL433Frame \"%s\"\n", msg.c_str());
-    }
+    debug("(rtl433) checkRTL433Frame \"%s\"\n", safeString(data).c_str());
 
     int payload_len = 0;
     size_t eolp = 0;

--- a/src/wmbus_rtlwmbus.cc
+++ b/src/wmbus_rtlwmbus.cc
@@ -354,11 +354,7 @@ FrameStatus WMBusRTLWMBUS::checkRTLWMBUSFrame(vector<uchar> &data,
     // There might be a second telegram on the same line ;0x4944.......
     if (data.size() == 0) return PartialFrame;
 
-    if (isDebugEnabled())
-    {
-        string msg = safeString(data);
-        debug("(rtlwmbus) checkRTLWMBusFrame \"%s\"\n", msg.c_str());
-    }
+    debug("(rtlwmbus) checkRTLWMBusFrame \"%s\"\n", safeString(data).c_str());
 
     int payload_len = 0;
     size_t eolp = 0;


### PR DESCRIPTION
debug() is a macro, which itself calls isDebugEnabled in an if condition. Calling explicitly isDebugEnabled() is only useful on a bundle of debug calls.