### PR TITLE
feat: introduce `critical()` and wmbusmeters specific exitcodes

### DIFF
--- a/src/bus.cc
+++ b/src/bus.cc
@@ -185,7 +185,7 @@ shared_ptr<BusDevice> BusManager::createWmbusObject(Detected *detected, Configur
     {
     case DEVICE_AUTO:
         assert(0);
-        critical("Internal error DEVICE_AUTO should not be used here!\n");
+        critical(EXIT_BUS_DEVICE_ERROR, "Internal error DEVICE_AUTO should not be used here!\n");
         break;
     case DEVICE_MBUS:
         verbose("(mbus) on %s\n", detected->found_file.c_str());
@@ -258,12 +258,12 @@ shared_ptr<BusDevice> BusManager::createWmbusObject(Detected *detected, Configur
         break;
     }
     case DEVICE_UNKNOWN:
-        warning("(main) internal error! cannot create an unknown device! exiting!\n");
+        error("(main) internal error! cannot create an unknown device! exiting!\n");
         if (config->daemon) {
             // If starting as a daemon, wait a bit so that systemd have time to catch up.
             sleep(1);
         }
-        exit(1);
+        exit(EXIT_DEVICE_ERROR);
         break;
     }
 

--- a/src/bus.cc
+++ b/src/bus.cc
@@ -185,7 +185,7 @@ shared_ptr<BusDevice> BusManager::createWmbusObject(Detected *detected, Configur
     {
     case DEVICE_AUTO:
         assert(0);
-        error("Internal error DEVICE_AUTO should not be used here!\n");
+        critical("Internal error DEVICE_AUTO should not be used here!\n");
         break;
     case DEVICE_MBUS:
         verbose("(mbus) on %s\n", detected->found_file.c_str());

--- a/src/cmdline.cc
+++ b/src/cmdline.cc
@@ -42,7 +42,7 @@ shared_ptr<Configuration> parseCommandLine(int argc, char **argv)
         c->daemon = true;
         if (argc < 2)
         {
-            error("Usage error: wmbusmetersd must have at least a single argument to the pid file.\n");
+            critical("Usage error: wmbusmetersd must have at least a single argument to the pid file.\n");
         }
         return parseCommandLineWithUseConfig(c, argc, argv, true);
     }
@@ -175,7 +175,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--device=", 9) || // Deprecated
             !strncmp(argv[i], "--overridedevice=", 17))
         {
-            error("You can only use --overridedevice=xyz with --useconfig=xyz\n");
+            critical("You can only use --overridedevice=xyz with --useconfig=xyz\n");
         }
         if (!strcmp(argv[i], "--version")) {
             c->version = true;
@@ -224,7 +224,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                 {
                     if (inv)
                     {
-                        error("Bad key \"%s\"", s.c_str());
+                        critical("Bad key \"%s\"", s.c_str());
                     }
                     c->analyze_key = s;
                 }
@@ -240,7 +240,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
 
                     if (mi.driver_name.str() == "")
                     {
-                        error("Not a valid meter driver \"%s\"\n", s.c_str());
+                        critical("Not a valid meter driver \"%s\"\n", s.c_str());
                     }
                     c->analyze_driver = s;
                 }
@@ -266,7 +266,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             }
             else
             {
-                error("No such timestamp setting \"%s\" possible values are: never always important\n",
+                critical("No such timestamp setting \"%s\" possible values are: never always important\n",
                       ts.c_str());
             }
             i++;
@@ -279,7 +279,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         }
         if (!strncmp(argv[i], "--profile=", 10)) {
             c->analyze_profile = atoi(argv[i]+10);
-            if (c->analyze_profile <= 0) error("Illegal profile value, must be greater than zero.\n");
+            if (c->analyze_profile <= 0) critical("Illegal profile value, must be greater than zero.\n");
             i++;
             continue;
         }
@@ -296,10 +296,10 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             LinkModeSet lms = parseLinkModes(argv[i]+11);
             if (lms.empty())
             {
-                error("Unknown default link mode \"%s\"!\n", argv[i]+11);
+                critical("Unknown default link mode \"%s\"!\n", argv[i]+11);
             }
             if (!c->default_device_linkmodes.empty()) {
-                error("You have already specified a default link mode!\n");
+                critical("You have already specified a default link mode!\n");
             }
             c->default_device_linkmodes = lms;
             i++;
@@ -310,7 +310,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (lm != LinkMode::UNKNOWN) {
             if (!c->default_device_linkmodes.empty())
             {
-                error("You have already specified a default link mode!\n");
+                critical("You have already specified a default link mode!\n");
             }
             // Add to the empty set.
             c->default_device_linkmodes.addLinkMode(lm);
@@ -356,7 +356,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             }
             else
             {
-                error("Unknown output format: \"%s\"\n", argv[i]+9);
+                critical("Unknown output format: \"%s\"\n", argv[i]+9);
             }
             i++;
             continue;
@@ -367,17 +367,17 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                 string s = string(argv[i]+15);
                 handleSelectedFields(c, s);
             } else {
-                error("You must supply fields to be selected.\n");
+                critical("You must supply fields to be selected.\n");
             }
             i++;
             continue;
         }
         if (!strncmp(argv[i], "--separator=", 12)) {
             if (!c->fields) {
-                error("You must specify --format=fields before --separator=X\n");
+                critical("You must specify --format=fields before --separator=X\n");
             }
             if (strlen(argv[i]) != 13) {
-                error("You must supply a single character as the field separator.\n");
+                critical("You must supply a single character as the field separator.\n");
             }
             c->separator = argv[i][12];
             i++;
@@ -390,10 +390,10 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                 } else if (!strncmp(argv[i]+19, "append", 6)) {
                     c->meterfiles_action = MeterFileType::Append;
                 } else {
-                    error("No such meter file action %s\n", argv[i]+19);
+                    critical("No such meter file action %s\n", argv[i]+19);
                 }
             } else {
-                error("Incorrect option %s\n", argv[i]);
+                critical("Incorrect option %s\n", argv[i]);
             }
             i++;
             continue;
@@ -413,10 +413,10 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                     c->meterfiles_naming = MeterFileNaming::Id;
                 } else
                 {
-                    error("No such meter file naming %s\n", argv[i]+19);
+                    critical("No such meter file naming %s\n", argv[i]+19);
                 }
             } else {
-                error("Incorrect option %s\n", argv[i]);
+                critical("Incorrect option %s\n", argv[i]);
             }
             i++;
             continue;
@@ -448,10 +448,10 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                     c->meterfiles_timestamp = MeterFileTimestamp::Never;
                 } else
                 {
-                    error("No such meter file timestamp \"%s\"\n", argv[i]+22);
+                    critical("No such meter file timestamp \"%s\"\n", argv[i]+22);
                 }
             } else {
-                error("Incorrect option %s\n", argv[i]);
+                critical("Incorrect option %s\n", argv[i]);
             }
             i++;
             continue;
@@ -469,7 +469,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                 c->meterfiles_dir = "/tmp";
             }
             if (!checkIfDirExists(c->meterfiles_dir.c_str())) {
-                error("Cannot write meter files into dir \"%s\"\n", c->meterfiles_dir.c_str());
+                critical("Cannot write meter files into dir \"%s\"\n", c->meterfiles_dir.c_str());
             }
             i++;
             continue;
@@ -481,7 +481,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                 if (len > 0) {
                     c->logfile = string(argv[i]+10, len);
                 } else {
-                    error("Not a valid log file name.\n");
+                    critical("Not a valid log file name.\n");
                 }
             }
             i++;
@@ -509,7 +509,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                 }
                 else
                 {
-                    error("You must specify true or false after --ignoreduplicates=\n");
+                    critical("You must specify true or false after --ignoreduplicates=\n");
                 }
             }
             i++;
@@ -528,7 +528,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--shell=", 8)) {
             string cmd = string(argv[i]+8);
             if (cmd == "") {
-                error("The telegram shell command cannot be empty.\n");
+                critical("The telegram shell command cannot be empty.\n");
             }
             c->telegram_shells.push_back(cmd);
             i++;
@@ -537,7 +537,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--metershell=", 13)) {
             string cmd = string(argv[i]+13);
             if (cmd == "") {
-                error("The meter shell command cannot be empty.\n");
+                critical("The meter shell command cannot be empty.\n");
             }
             c->new_meter_shells.push_back(cmd);
             i++;
@@ -546,7 +546,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--alarmshell=", 13)) {
             string cmd = string(argv[i]+13);
             if (cmd == "") {
-                error("The alarm shell command cannot be empty.\n");
+                critical("The alarm shell command cannot be empty.\n");
             }
             c->alarm_shells.push_back(cmd);
             i++;
@@ -563,7 +563,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
 
             string extra_constant_field = string(argv[i]+off);
             if (extra_constant_field == "") {
-                error("The extra constant field command cannot be empty.\n");
+                critical("The extra constant field command cannot be empty.\n");
             }
             // The extra "floor"="42" will be pushed to the json.
             debug("Added extra constant field %s\n", extra_constant_field.c_str());
@@ -576,7 +576,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             // For example: --calculate_adjusted_kwh='total_kwh + 12345 kwh'
             string extra_calculated_field = string(argv[i]+12);
             if (extra_calculated_field == "") {
-                error("The calculated field command cannot be empty.\n");
+                critical("The calculated field command cannot be empty.\n");
             }
             debug("(cmdline) add calculated field %s\n", extra_calculated_field.c_str());
             c->extra_calculated_fields.push_back(extra_calculated_field);
@@ -626,7 +626,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--exitafter=", 12) && strlen(argv[i]) > 12) {
             c->exitafter = parseTime(argv[i]+12);
             if (c->exitafter <= 0) {
-                error("Not a valid time to exit after. \"%s\"\n", argv[i]+12);
+                critical("Not a valid time to exit after. \"%s\"\n", argv[i]+12);
             }
             i++;
             continue;
@@ -649,7 +649,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--pollinterval=", 15) && strlen(argv[i]) > 15) {
             c->pollinterval = parseTime(argv[i]+15);
             if (c->pollinterval <= 0) {
-                error("Not a valid time to regularly poll meters. \"%s\"\n", argv[i]+15);
+                critical("Not a valid time to regularly poll meters. \"%s\"\n", argv[i]+15);
             }
             i++;
             continue;
@@ -658,7 +658,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             c->identity_mode = toIdentityMode(argv[i]+15);
             if (c->identity_mode == IdentityMode::INVALID)
             {
-                error("Not a valid identity mode. \"%s\"\n", argv[i]+15);
+                critical("Not a valid identity mode. \"%s\"\n", argv[i]+15);
             }
             i++;
             continue;
@@ -666,7 +666,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--resetafter=", 13) && strlen(argv[i]) > 13) {
             c->resetafter = parseTime(argv[i]+13);
             if (c->resetafter <= 0) {
-                error("Not a valid time to regularly reset after. \"%s\"\n", argv[i]+13);
+                critical("Not a valid time to regularly reset after. \"%s\"\n", argv[i]+13);
             }
             i++;
             continue;
@@ -674,7 +674,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--alarmtimeout=", 15)) {
             c->alarm_timeout = parseTime(argv[i]+15);
             if (c->alarm_timeout <= 0) {
-                error("Not a valid alarm timeout. \"%s\"\n", argv[i]+15);
+                critical("Not a valid alarm timeout. \"%s\"\n", argv[i]+15);
             }
             i++;
             continue;
@@ -683,7 +683,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             string ea = string(argv[i]+24);
             if (!isValidTimePeriod(ea))
             {
-                error("Not a valid time period string. \"%s\"\n", ea.c_str());
+                critical("Not a valid time period string. \"%s\"\n", ea.c_str());
             }
             c->alarm_expected_activity = ea;
             i++;
@@ -695,7 +695,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             c->drivers_dir = string(argv[i]+13, len);
             if (!checkIfDirExists(c->drivers_dir.c_str()))
             {
-                error("You must supply a valid directory to --driversdir=<dir>\n");
+                critical("You must supply a valid directory to --driversdir=<dir>\n");
             }
             i++;
             loadDriversFromDir(c->drivers_dir);
@@ -707,14 +707,14 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             string file_name = string(argv[i]+9, len);
             if (!checkFileExists(file_name.c_str()))
             {
-                error("You must supply a valid file to --driver=<file>\n");
+                critical("You must supply a valid file to --driver=<file>\n");
             }
             i++;
             loadDriver(file_name, NULL);
             continue;
         }
 
-        error("Unknown option \"%s\"\n", argv[i]);
+        critical("Unknown option \"%s\"\n", argv[i]);
     }
 
     bool found_at_least_one_device_or_hex = false;
@@ -723,7 +723,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--", 2))
         {
             // We have found a device and the next parameter is an option.
-            error("All command line options must be placed before the devices, %s is placed wrong.\n", argv[i]);
+            critical("All command line options must be placed before the devices, %s is placed wrong.\n", argv[i]);
         }
         bool ok = handleDeviceOrHex(c, argv[i]);
         if (ok)
@@ -734,7 +734,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         {
             if (!found_at_least_one_device_or_hex)
             {
-                error("At least one valid device (or hex) must be supplied!\n");
+                critical("At least one valid device (or hex) must be supplied!\n");
             }
             // There are more arguments...
             break;
@@ -750,7 +750,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         !c->list_units &&
         !c->print_driver)
     {
-        error("You must supply at least one device to communicate using (w)mbus.\n");
+        critical("You must supply at least one device to communicate using (w)mbus.\n");
     }
 
     while (argv[i] != 0 && SendBusContent::isLikely(argv[i]))
@@ -759,14 +759,14 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         bool ok = sbc.parse(argv[i]);
         if (!ok)
         {
-            error("Not a valid send bus content command.\n");
+            critical("Not a valid send bus content command.\n");
         }
         c->send_bus_content.push_back(sbc);
         i++;
     }
 
     if ((argc-i) % 4 != 0) {
-        error("For each meter you must supply a: name,type,id and key.\n");
+        critical("For each meter you must supply a: name,type,id and key.\n");
     }
     int num_meters = (argc-i)/4;
 
@@ -782,7 +782,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
 
         if (!isValidSequenceOfAddressExpressions(address_expressions))
         {
-            error("Not a valid meter id nor a valid sequence of match expression \"%s\"\n", address_expressions.c_str());
+            critical("Not a valid meter id nor a valid sequence of match expression \"%s\"\n", address_expressions.c_str());
         }
 
         mi.parse(name, driver, address_expressions, key);
@@ -791,12 +791,12 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
 
         if (!isValidKey(key, mi))
         {
-            error("Not a valid meter key \"%s\"\n", key.c_str());
+            critical("Not a valid meter key \"%s\"\n", key.c_str());
         }
 
         if (mi.driver_name.str() == "")
         {
-            error("Not a valid meter driver \"%s\"\n", driver.c_str());
+            critical("Not a valid meter driver \"%s\"\n", driver.c_str());
         }
 
         c->meters.push_back(mi);
@@ -829,7 +829,7 @@ shared_ptr<Configuration> parseCommandLineWithUseConfig(Configuration *c, int ar
             }
             else
             {
-                error("You must supply a directory to --useconfig=dir\n");
+                critical("You must supply a directory to --useconfig=dir\n");
             }
             i++;
             continue;
@@ -914,7 +914,7 @@ shared_ptr<Configuration> parseCommandLineWithUseConfig(Configuration *c, int ar
         if (!strncmp(argv[i], "--exitafter=", 12) && strlen(argv[i]) > 12) {
             int s = parseTime(argv[i]+12);
             if (s <= 0) {
-                error("Not a valid time to exit after. \"%s\"\n", argv[i]+12);
+                critical("Not a valid time to exit after. \"%s\"\n", argv[i]+12);
             }
             c->overrides.exitafter_override = argv[i]+12;
             i++;
@@ -930,13 +930,13 @@ shared_ptr<Configuration> parseCommandLineWithUseConfig(Configuration *c, int ar
             if (len > 0) {
                 c->overrides.logfile_override = string(argv[i]+10, len);
             } else {
-                error("Not a valid log file name.\n");
+                critical("Not a valid log file name.\n");
             }
             i++;
             continue;
         }
 
-        error("Usage error: --useconfig=... can only be used in combination with:\n"
+        critical("Usage error: --useconfig=... can only be used in combination with:\n"
               "--overridedevice= --listento= --listmeters= --listfields= --exitafter= --oneshot= --logfile= --silent --normal --verbose --debug --trace\n");
         break;
     }
@@ -945,25 +945,25 @@ shared_ptr<Configuration> parseCommandLineWithUseConfig(Configuration *c, int ar
     {
         if (!argv[i])
         {
-            error("Usage error: you must supply the pid file as the last argument to wmbusmetersd.\n");
+            critical("Usage error: you must supply the pid file as the last argument to wmbusmetersd.\n");
         }
         if (argv[i][0] == '-')
         {
-            error("Usage error: the pid file name must not start with minus (-). Please change \"%s\".\n", argv[i]);
+            critical("Usage error: the pid file name must not start with minus (-). Please change \"%s\".\n", argv[i]);
         }
         c->pid_file = argv[i];
         i++;
 
         if (i < argc)
         {
-            error("Usage error: you must supply the pid file as the last argument to wmbusmetersd.\n");
+            critical("Usage error: you must supply the pid file as the last argument to wmbusmetersd.\n");
         }
     }
     else
     {
         if (i < argc)
         {
-            error("Usage error: too many arguments \"%s\" with --useconfig=...\n", argv[i]);
+            critical("Usage error: too many arguments \"%s\" with --useconfig=...\n", argv[i]);
         }
     }
     return shared_ptr<Configuration>(c);

--- a/src/cmdline.cc
+++ b/src/cmdline.cc
@@ -42,7 +42,7 @@ shared_ptr<Configuration> parseCommandLine(int argc, char **argv)
         c->daemon = true;
         if (argc < 2)
         {
-            critical("Usage error: wmbusmetersd must have at least a single argument to the pid file.\n");
+            critical(EXIT_CMDLINE_ERROR, "Usage error: wmbusmetersd must have at least a single argument to the pid file.\n");
         }
         return parseCommandLineWithUseConfig(c, argc, argv, true);
     }
@@ -175,7 +175,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--device=", 9) || // Deprecated
             !strncmp(argv[i], "--overridedevice=", 17))
         {
-            critical("You can only use --overridedevice=xyz with --useconfig=xyz\n");
+            critical(EXIT_CMDLINE_ERROR, "You can only use --overridedevice=xyz with --useconfig=xyz\n");
         }
         if (!strcmp(argv[i], "--version")) {
             c->version = true;
@@ -224,7 +224,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                 {
                     if (inv)
                     {
-                        critical("Bad key \"%s\"", s.c_str());
+                        critical(EXIT_CMDLINE_ERROR, "Bad key \"%s\"", s.c_str());
                     }
                     c->analyze_key = s;
                 }
@@ -240,7 +240,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
 
                     if (mi.driver_name.str() == "")
                     {
-                        critical("Not a valid meter driver \"%s\"\n", s.c_str());
+                        critical(EXIT_CMDLINE_ERROR, "Not a valid meter driver \"%s\"\n", s.c_str());
                     }
                     c->analyze_driver = s;
                 }
@@ -266,7 +266,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             }
             else
             {
-                critical("No such timestamp setting \"%s\" possible values are: never always important\n",
+                critical(EXIT_CMDLINE_ERROR, "No such timestamp setting \"%s\" possible values are: never always important\n",
                       ts.c_str());
             }
             i++;
@@ -279,7 +279,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         }
         if (!strncmp(argv[i], "--profile=", 10)) {
             c->analyze_profile = atoi(argv[i]+10);
-            if (c->analyze_profile <= 0) critical("Illegal profile value, must be greater than zero.\n");
+            if (c->analyze_profile <= 0) critical(EXIT_CMDLINE_ERROR, "Illegal profile value, must be greater than zero.\n");
             i++;
             continue;
         }
@@ -296,10 +296,10 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             LinkModeSet lms = parseLinkModes(argv[i]+11);
             if (lms.empty())
             {
-                critical("Unknown default link mode \"%s\"!\n", argv[i]+11);
+                critical(EXIT_CMDLINE_ERROR, "Unknown default link mode \"%s\"!\n", argv[i]+11);
             }
             if (!c->default_device_linkmodes.empty()) {
-                critical("You have already specified a default link mode!\n");
+                critical(EXIT_CMDLINE_ERROR, "You have already specified a default link mode!\n");
             }
             c->default_device_linkmodes = lms;
             i++;
@@ -310,7 +310,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (lm != LinkMode::UNKNOWN) {
             if (!c->default_device_linkmodes.empty())
             {
-                critical("You have already specified a default link mode!\n");
+                critical(EXIT_CMDLINE_ERROR, "You have already specified a default link mode!\n");
             }
             // Add to the empty set.
             c->default_device_linkmodes.addLinkMode(lm);
@@ -356,7 +356,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             }
             else
             {
-                critical("Unknown output format: \"%s\"\n", argv[i]+9);
+                critical(EXIT_CMDLINE_ERROR, "Unknown output format: \"%s\"\n", argv[i]+9);
             }
             i++;
             continue;
@@ -367,17 +367,17 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                 string s = string(argv[i]+15);
                 handleSelectedFields(c, s);
             } else {
-                critical("You must supply fields to be selected.\n");
+                critical(EXIT_CMDLINE_ERROR, "You must supply fields to be selected.\n");
             }
             i++;
             continue;
         }
         if (!strncmp(argv[i], "--separator=", 12)) {
             if (!c->fields) {
-                critical("You must specify --format=fields before --separator=X\n");
+                critical(EXIT_CMDLINE_ERROR, "You must specify --format=fields before --separator=X\n");
             }
             if (strlen(argv[i]) != 13) {
-                critical("You must supply a single character as the field separator.\n");
+                critical(EXIT_CMDLINE_ERROR, "You must supply a single character as the field separator.\n");
             }
             c->separator = argv[i][12];
             i++;
@@ -390,10 +390,10 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                 } else if (!strncmp(argv[i]+19, "append", 6)) {
                     c->meterfiles_action = MeterFileType::Append;
                 } else {
-                    critical("No such meter file action %s\n", argv[i]+19);
+                    critical(EXIT_CMDLINE_ERROR, "No such meter file action %s\n", argv[i]+19);
                 }
             } else {
-                critical("Incorrect option %s\n", argv[i]);
+                critical(EXIT_CMDLINE_ERROR, "Incorrect option %s\n", argv[i]);
             }
             i++;
             continue;
@@ -413,10 +413,10 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                     c->meterfiles_naming = MeterFileNaming::Id;
                 } else
                 {
-                    critical("No such meter file naming %s\n", argv[i]+19);
+                    critical(EXIT_CMDLINE_ERROR, "No such meter file naming %s\n", argv[i]+19);
                 }
             } else {
-                critical("Incorrect option %s\n", argv[i]);
+                critical(EXIT_CMDLINE_ERROR, "Incorrect option %s\n", argv[i]);
             }
             i++;
             continue;
@@ -448,10 +448,10 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                     c->meterfiles_timestamp = MeterFileTimestamp::Never;
                 } else
                 {
-                    critical("No such meter file timestamp \"%s\"\n", argv[i]+22);
+                    critical(EXIT_CMDLINE_ERROR, "No such meter file timestamp \"%s\"\n", argv[i]+22);
                 }
             } else {
-                critical("Incorrect option %s\n", argv[i]);
+                critical(EXIT_CMDLINE_ERROR, "Incorrect option %s\n", argv[i]);
             }
             i++;
             continue;
@@ -469,7 +469,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                 c->meterfiles_dir = "/tmp";
             }
             if (!checkIfDirExists(c->meterfiles_dir.c_str())) {
-                critical("Cannot write meter files into dir \"%s\"\n", c->meterfiles_dir.c_str());
+                critical(EXIT_CMDLINE_ERROR, "Cannot write meter files into dir \"%s\"\n", c->meterfiles_dir.c_str());
             }
             i++;
             continue;
@@ -481,7 +481,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                 if (len > 0) {
                     c->logfile = string(argv[i]+10, len);
                 } else {
-                    critical("Not a valid log file name.\n");
+                    critical(EXIT_CMDLINE_ERROR, "Not a valid log file name.\n");
                 }
             }
             i++;
@@ -509,7 +509,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
                 }
                 else
                 {
-                    critical("You must specify true or false after --ignoreduplicates=\n");
+                    critical(EXIT_CMDLINE_ERROR, "You must specify true or false after --ignoreduplicates=\n");
                 }
             }
             i++;
@@ -528,7 +528,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--shell=", 8)) {
             string cmd = string(argv[i]+8);
             if (cmd == "") {
-                critical("The telegram shell command cannot be empty.\n");
+                critical(EXIT_CMDLINE_ERROR, "The telegram shell command cannot be empty.\n");
             }
             c->telegram_shells.push_back(cmd);
             i++;
@@ -537,7 +537,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--metershell=", 13)) {
             string cmd = string(argv[i]+13);
             if (cmd == "") {
-                critical("The meter shell command cannot be empty.\n");
+                critical(EXIT_CMDLINE_ERROR, "The meter shell command cannot be empty.\n");
             }
             c->new_meter_shells.push_back(cmd);
             i++;
@@ -546,7 +546,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--alarmshell=", 13)) {
             string cmd = string(argv[i]+13);
             if (cmd == "") {
-                critical("The alarm shell command cannot be empty.\n");
+                critical(EXIT_CMDLINE_ERROR, "The alarm shell command cannot be empty.\n");
             }
             c->alarm_shells.push_back(cmd);
             i++;
@@ -563,7 +563,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
 
             string extra_constant_field = string(argv[i]+off);
             if (extra_constant_field == "") {
-                critical("The extra constant field command cannot be empty.\n");
+                critical(EXIT_CMDLINE_ERROR, "The extra constant field command cannot be empty.\n");
             }
             // The extra "floor"="42" will be pushed to the json.
             debug("Added extra constant field %s\n", extra_constant_field.c_str());
@@ -576,7 +576,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             // For example: --calculate_adjusted_kwh='total_kwh + 12345 kwh'
             string extra_calculated_field = string(argv[i]+12);
             if (extra_calculated_field == "") {
-                critical("The calculated field command cannot be empty.\n");
+                critical(EXIT_CMDLINE_ERROR, "The calculated field command cannot be empty.\n");
             }
             debug("(cmdline) add calculated field %s\n", extra_calculated_field.c_str());
             c->extra_calculated_fields.push_back(extra_calculated_field);
@@ -626,7 +626,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--exitafter=", 12) && strlen(argv[i]) > 12) {
             c->exitafter = parseTime(argv[i]+12);
             if (c->exitafter <= 0) {
-                critical("Not a valid time to exit after. \"%s\"\n", argv[i]+12);
+                critical(EXIT_CMDLINE_ERROR, "Not a valid time to exit after. \"%s\"\n", argv[i]+12);
             }
             i++;
             continue;
@@ -649,7 +649,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--pollinterval=", 15) && strlen(argv[i]) > 15) {
             c->pollinterval = parseTime(argv[i]+15);
             if (c->pollinterval <= 0) {
-                critical("Not a valid time to regularly poll meters. \"%s\"\n", argv[i]+15);
+                critical(EXIT_CMDLINE_ERROR, "Not a valid time to regularly poll meters. \"%s\"\n", argv[i]+15);
             }
             i++;
             continue;
@@ -658,7 +658,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             c->identity_mode = toIdentityMode(argv[i]+15);
             if (c->identity_mode == IdentityMode::INVALID)
             {
-                critical("Not a valid identity mode. \"%s\"\n", argv[i]+15);
+                critical(EXIT_CMDLINE_ERROR, "Not a valid identity mode. \"%s\"\n", argv[i]+15);
             }
             i++;
             continue;
@@ -666,7 +666,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--resetafter=", 13) && strlen(argv[i]) > 13) {
             c->resetafter = parseTime(argv[i]+13);
             if (c->resetafter <= 0) {
-                critical("Not a valid time to regularly reset after. \"%s\"\n", argv[i]+13);
+                critical(EXIT_CMDLINE_ERROR, "Not a valid time to regularly reset after. \"%s\"\n", argv[i]+13);
             }
             i++;
             continue;
@@ -674,7 +674,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--alarmtimeout=", 15)) {
             c->alarm_timeout = parseTime(argv[i]+15);
             if (c->alarm_timeout <= 0) {
-                critical("Not a valid alarm timeout. \"%s\"\n", argv[i]+15);
+                critical(EXIT_CMDLINE_ERROR, "Not a valid alarm timeout. \"%s\"\n", argv[i]+15);
             }
             i++;
             continue;
@@ -683,7 +683,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             string ea = string(argv[i]+24);
             if (!isValidTimePeriod(ea))
             {
-                critical("Not a valid time period string. \"%s\"\n", ea.c_str());
+                critical(EXIT_CMDLINE_ERROR, "Not a valid time period string. \"%s\"\n", ea.c_str());
             }
             c->alarm_expected_activity = ea;
             i++;
@@ -695,7 +695,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             c->drivers_dir = string(argv[i]+13, len);
             if (!checkIfDirExists(c->drivers_dir.c_str()))
             {
-                critical("You must supply a valid directory to --driversdir=<dir>\n");
+                critical(EXIT_CMDLINE_ERROR, "You must supply a valid directory to --driversdir=<dir>\n");
             }
             i++;
             loadDriversFromDir(c->drivers_dir);
@@ -707,14 +707,14 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
             string file_name = string(argv[i]+9, len);
             if (!checkFileExists(file_name.c_str()))
             {
-                critical("You must supply a valid file to --driver=<file>\n");
+                critical(EXIT_CMDLINE_ERROR, "You must supply a valid file to --driver=<file>\n");
             }
             i++;
             loadDriver(file_name, NULL);
             continue;
         }
 
-        critical("Unknown option \"%s\"\n", argv[i]);
+        critical(EXIT_CMDLINE_ERROR, "Unknown option \"%s\"\n", argv[i]);
     }
 
     bool found_at_least_one_device_or_hex = false;
@@ -723,7 +723,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         if (!strncmp(argv[i], "--", 2))
         {
             // We have found a device and the next parameter is an option.
-            critical("All command line options must be placed before the devices, %s is placed wrong.\n", argv[i]);
+            critical(EXIT_CMDLINE_ERROR, "All command line options must be placed before the devices, %s is placed wrong.\n", argv[i]);
         }
         bool ok = handleDeviceOrHex(c, argv[i]);
         if (ok)
@@ -734,7 +734,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         {
             if (!found_at_least_one_device_or_hex)
             {
-                critical("At least one valid device (or hex) must be supplied!\n");
+                critical(EXIT_CMDLINE_ERROR, "At least one valid device (or hex) must be supplied!\n");
             }
             // There are more arguments...
             break;
@@ -750,7 +750,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         !c->list_units &&
         !c->print_driver)
     {
-        critical("You must supply at least one device to communicate using (w)mbus.\n");
+        critical(EXIT_CMDLINE_ERROR, "You must supply at least one device to communicate using (w)mbus.\n");
     }
 
     while (argv[i] != 0 && SendBusContent::isLikely(argv[i]))
@@ -759,14 +759,14 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
         bool ok = sbc.parse(argv[i]);
         if (!ok)
         {
-            critical("Not a valid send bus content command.\n");
+            critical(EXIT_CMDLINE_ERROR, "Not a valid send bus content command.\n");
         }
         c->send_bus_content.push_back(sbc);
         i++;
     }
 
     if ((argc-i) % 4 != 0) {
-        critical("For each meter you must supply a: name,type,id and key.\n");
+        critical(EXIT_CMDLINE_ERROR, "For each meter you must supply a: name,type,id and key.\n");
     }
     int num_meters = (argc-i)/4;
 
@@ -782,7 +782,7 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
 
         if (!isValidSequenceOfAddressExpressions(address_expressions))
         {
-            critical("Not a valid meter id nor a valid sequence of match expression \"%s\"\n", address_expressions.c_str());
+            critical(EXIT_CMDLINE_ERROR, "Not a valid meter id nor a valid sequence of match expression \"%s\"\n", address_expressions.c_str());
         }
 
         mi.parse(name, driver, address_expressions, key);
@@ -791,12 +791,12 @@ static shared_ptr<Configuration> parseNormalCommandLine(Configuration *c, int ar
 
         if (!isValidKey(key, mi))
         {
-            critical("Not a valid meter key \"%s\"\n", key.c_str());
+            critical(EXIT_CMDLINE_ERROR, "Not a valid meter key \"%s\"\n", key.c_str());
         }
 
         if (mi.driver_name.str() == "")
         {
-            critical("Not a valid meter driver \"%s\"\n", driver.c_str());
+            critical(EXIT_CMDLINE_ERROR, "Not a valid meter driver \"%s\"\n", driver.c_str());
         }
 
         c->meters.push_back(mi);
@@ -829,7 +829,7 @@ shared_ptr<Configuration> parseCommandLineWithUseConfig(Configuration *c, int ar
             }
             else
             {
-                critical("You must supply a directory to --useconfig=dir\n");
+                critical(EXIT_CMDLINE_ERROR, "You must supply a directory to --useconfig=dir\n");
             }
             i++;
             continue;
@@ -914,7 +914,7 @@ shared_ptr<Configuration> parseCommandLineWithUseConfig(Configuration *c, int ar
         if (!strncmp(argv[i], "--exitafter=", 12) && strlen(argv[i]) > 12) {
             int s = parseTime(argv[i]+12);
             if (s <= 0) {
-                critical("Not a valid time to exit after. \"%s\"\n", argv[i]+12);
+                critical(EXIT_CMDLINE_ERROR, "Not a valid time to exit after. \"%s\"\n", argv[i]+12);
             }
             c->overrides.exitafter_override = argv[i]+12;
             i++;
@@ -930,13 +930,13 @@ shared_ptr<Configuration> parseCommandLineWithUseConfig(Configuration *c, int ar
             if (len > 0) {
                 c->overrides.logfile_override = string(argv[i]+10, len);
             } else {
-                critical("Not a valid log file name.\n");
+                critical(EXIT_CMDLINE_ERROR, "Not a valid log file name.\n");
             }
             i++;
             continue;
         }
 
-        critical("Usage error: --useconfig=... can only be used in combination with:\n"
+        critical(EXIT_CMDLINE_ERROR, "Usage error: --useconfig=... can only be used in combination with:\n"
               "--overridedevice= --listento= --listmeters= --listfields= --exitafter= --oneshot= --logfile= --silent --normal --verbose --debug --trace\n");
         break;
     }
@@ -945,25 +945,25 @@ shared_ptr<Configuration> parseCommandLineWithUseConfig(Configuration *c, int ar
     {
         if (!argv[i])
         {
-            critical("Usage error: you must supply the pid file as the last argument to wmbusmetersd.\n");
+            critical(EXIT_CMDLINE_ERROR, "Usage error: you must supply the pid file as the last argument to wmbusmetersd.\n");
         }
         if (argv[i][0] == '-')
         {
-            critical("Usage error: the pid file name must not start with minus (-). Please change \"%s\".\n", argv[i]);
+            critical(EXIT_CMDLINE_ERROR, "Usage error: the pid file name must not start with minus (-). Please change \"%s\".\n", argv[i]);
         }
         c->pid_file = argv[i];
         i++;
 
         if (i < argc)
         {
-            critical("Usage error: you must supply the pid file as the last argument to wmbusmetersd.\n");
+            critical(EXIT_CMDLINE_ERROR, "Usage error: you must supply the pid file as the last argument to wmbusmetersd.\n");
         }
     }
     else
     {
         if (i < argc)
         {
-            critical("Usage error: too many arguments \"%s\" with --useconfig=...\n", argv[i]);
+            critical(EXIT_CMDLINE_ERROR, "Usage error: too many arguments \"%s\" with --useconfig=...\n", argv[i]);
         }
     }
     return shared_ptr<Configuration>(c);

--- a/src/config.cc
+++ b/src/config.cc
@@ -154,13 +154,13 @@ void parseMeterConfig(Configuration *c, vector<char> &buf, string file)
         {
             if (poll_interval != 0)
             {
-                critical("You have already specified a poll interval for this meter!\n");
+                critical(EXIT_CONFIG_ERROR, "You have already specified a poll interval for this meter!\n");
             }
             poll_interval = parseTime(p.second);
 
             if (poll_interval == 0)
             {
-                critical("Poll interval must be non-zero \"%s\"!\n", p.second.c_str());
+                critical(EXIT_CONFIG_ERROR, "Poll interval must be non-zero \"%s\"!\n", p.second.c_str());
             }
         }
         else if (p.first == "identitymode")
@@ -169,7 +169,7 @@ void parseMeterConfig(Configuration *c, vector<char> &buf, string file)
 
             if (identity_mode == IdentityMode::INVALID)
             {
-                critical("Invalid identity mode: \"%s\"!\n", p.second.c_str());
+                critical(EXIT_CONFIG_ERROR, "Invalid identity mode: \"%s\"!\n", p.second.c_str());
             }
         }
         else if (p.first == "shell")
@@ -399,7 +399,7 @@ bool handleDeviceOrHex(Configuration *c, string devicefilehex)
     {
         if (invalid_hex)
         {
-            critical("Bad hex: \"%s\"\nHex string must have an even length of hexadecimal characters.\n", devicefilehex.c_str());
+            critical(EXIT_CONFIG_ERROR, "Bad hex: \"%s\"\nHex string must have an even length of hexadecimal characters.\n", devicefilehex.c_str());
         }
     }
 
@@ -407,7 +407,7 @@ bool handleDeviceOrHex(Configuration *c, string devicefilehex)
     bool ok = specified_device.parse(devicefilehex);
     if (!ok && SpecifiedDevice::isLikelyDevice(devicefilehex))
     {
-        critical("Not a valid device \"%s\"\n", devicefilehex.c_str());
+        critical(EXIT_CONFIG_ERROR, "Not a valid device \"%s\"\n", devicefilehex.c_str());
     }
 
     if (!ok) return false;
@@ -421,7 +421,7 @@ bool handleDeviceOrHex(Configuration *c, string devicefilehex)
     {
         if (!specified_device.linkmodes.empty())
         {
-            critical("An mbus device must not have linkmode set. \"%s\"\n", devicefilehex.c_str());
+            critical(EXIT_CONFIG_ERROR, "An mbus device must not have linkmode set. \"%s\"\n", devicefilehex.c_str());
         }
     }
 
@@ -452,11 +452,11 @@ bool handleDeviceOrHex(Configuration *c, string devicefilehex)
     {
         if (c->single_device_override)
         {
-            critical("You can only specify one stdin or one file or one command!\n");
+            critical(EXIT_CONFIG_ERROR, "You can only specify one stdin or one file or one command!\n");
         }
         if (c->use_auto_device_detect)
         {
-            critical("You cannot mix auto with stdin or a file.\n");
+            critical(EXIT_CONFIG_ERROR, "You cannot mix auto with stdin or a file.\n");
         }
         if (specified_device.is_simulation) c->simulation_found = true;
         c->single_device_override = true;
@@ -494,11 +494,11 @@ void handleListenTo(Configuration *c, string mode)
     LinkModeSet lms = parseLinkModes(mode.c_str());
     if (lms.empty())
     {
-        critical("Unknown link modes \"%s\"!\n", mode.c_str());
+        critical(EXIT_CONFIG_ERROR, "Unknown link modes \"%s\"!\n", mode.c_str());
     }
     if (!c->default_device_linkmodes.empty())
     {
-        critical("You have already specified the default link modes!\n");
+        critical(EXIT_CONFIG_ERROR, "You have already specified the default link modes!\n");
     }
 
     c->default_device_linkmodes = lms;
@@ -508,14 +508,14 @@ void handleExitAfter(Configuration *c, string after)
 {
     if (c->exitafter > 0)
     {
-        critical("You have already specified an exit after time!\n");
+        critical(EXIT_CONFIG_ERROR, "You have already specified an exit after time!\n");
     }
 
     c->exitafter = parseTime(after);
 
     if (c->exitafter == 0)
     {
-        critical("Exit after time must be non-zero \"%s\"!\n", after.c_str());
+        critical(EXIT_CONFIG_ERROR, "Exit after time must be non-zero \"%s\"!\n", after.c_str());
     }
 }
 
@@ -774,10 +774,12 @@ shared_ptr<Configuration> loadConfiguration(string root, ConfigOverrides overrid
     }
 
     debug("(config) loading %s\n", conf_file.c_str());
-    bool ok = loadFile(conf_file, &global_conf);
-    global_conf.push_back('\n');
 
-    if (!ok) exit(1);
+    if (!loadFile(conf_file, &global_conf)) {
+        critical(EXIT_CONFIG_ERROR, "Cannot load config file \"%s\"\n", conf_file.c_str());
+    }
+
+    global_conf.push_back('\n');
 
     auto i = global_conf.begin();
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -154,13 +154,13 @@ void parseMeterConfig(Configuration *c, vector<char> &buf, string file)
         {
             if (poll_interval != 0)
             {
-                error("You have already specified a poll interval for this meter!\n");
+                critical("You have already specified a poll interval for this meter!\n");
             }
             poll_interval = parseTime(p.second);
 
             if (poll_interval == 0)
             {
-                error("Poll interval must be non-zero \"%s\"!\n", p.second.c_str());
+                critical("Poll interval must be non-zero \"%s\"!\n", p.second.c_str());
             }
         }
         else if (p.first == "identitymode")
@@ -169,7 +169,7 @@ void parseMeterConfig(Configuration *c, vector<char> &buf, string file)
 
             if (identity_mode == IdentityMode::INVALID)
             {
-                error("Invalid identity mode: \"%s\"!\n", p.second.c_str());
+                critical("Invalid identity mode: \"%s\"!\n", p.second.c_str());
             }
         }
         else if (p.first == "shell")
@@ -399,7 +399,7 @@ bool handleDeviceOrHex(Configuration *c, string devicefilehex)
     {
         if (invalid_hex)
         {
-            error("Bad hex: \"%s\"\nHex string must have an even length of hexadecimal characters.\n", devicefilehex.c_str());
+            critical("Bad hex: \"%s\"\nHex string must have an even length of hexadecimal characters.\n", devicefilehex.c_str());
         }
     }
 
@@ -407,7 +407,7 @@ bool handleDeviceOrHex(Configuration *c, string devicefilehex)
     bool ok = specified_device.parse(devicefilehex);
     if (!ok && SpecifiedDevice::isLikelyDevice(devicefilehex))
     {
-        error("Not a valid device \"%s\"\n", devicefilehex.c_str());
+        critical("Not a valid device \"%s\"\n", devicefilehex.c_str());
     }
 
     if (!ok) return false;
@@ -421,7 +421,7 @@ bool handleDeviceOrHex(Configuration *c, string devicefilehex)
     {
         if (!specified_device.linkmodes.empty())
         {
-            error("An mbus device must not have linkmode set. \"%s\"\n", devicefilehex.c_str());
+            critical("An mbus device must not have linkmode set. \"%s\"\n", devicefilehex.c_str());
         }
     }
 
@@ -452,11 +452,11 @@ bool handleDeviceOrHex(Configuration *c, string devicefilehex)
     {
         if (c->single_device_override)
         {
-            error("You can only specify one stdin or one file or one command!\n");
+            critical("You can only specify one stdin or one file or one command!\n");
         }
         if (c->use_auto_device_detect)
         {
-            error("You cannot mix auto with stdin or a file.\n");
+            critical("You cannot mix auto with stdin or a file.\n");
         }
         if (specified_device.is_simulation) c->simulation_found = true;
         c->single_device_override = true;
@@ -494,11 +494,11 @@ void handleListenTo(Configuration *c, string mode)
     LinkModeSet lms = parseLinkModes(mode.c_str());
     if (lms.empty())
     {
-        error("Unknown link modes \"%s\"!\n", mode.c_str());
+        critical("Unknown link modes \"%s\"!\n", mode.c_str());
     }
     if (!c->default_device_linkmodes.empty())
     {
-        error("You have already specified the default link modes!\n");
+        critical("You have already specified the default link modes!\n");
     }
 
     c->default_device_linkmodes = lms;
@@ -508,14 +508,14 @@ void handleExitAfter(Configuration *c, string after)
 {
     if (c->exitafter > 0)
     {
-        error("You have already specified an exit after time!\n");
+        critical("You have already specified an exit after time!\n");
     }
 
     c->exitafter = parseTime(after);
 
     if (c->exitafter == 0)
     {
-        error("Exit after time must be non-zero \"%s\"!\n", after.c_str());
+        critical("Exit after time must be non-zero \"%s\"!\n", after.c_str());
     }
 }
 

--- a/src/dvparser.cc
+++ b/src/dvparser.cc
@@ -1313,7 +1313,7 @@ bool DVEntry::extractLong(uint64_t *out)
     }
     else
     {
-        error("Unsupported dif format for extraction to long! dif=%02x\n", dif_vif_key.dif());
+        critical("Unsupported dif format for extraction to long! dif=%02x\n", dif_vif_key.dif());
     }
 
     return true;

--- a/src/dvparser.cc
+++ b/src/dvparser.cc
@@ -1313,7 +1313,7 @@ bool DVEntry::extractLong(uint64_t *out)
     }
     else
     {
-        critical("Unsupported dif format for extraction to long! dif=%02x\n", dif_vif_key.dif());
+        critical(EXIT_DRIVER_ERROR, "Unsupported dif format for extraction to long! dif=%02x\n", dif_vif_key.dif());
     }
 
     return true;

--- a/src/exitcodes.h
+++ b/src/exitcodes.h
@@ -1,0 +1,30 @@
+/*
+ Copyright (C) 2024 Fredrik Öhrström (gpl-3.0-or-later)
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef EXITCODES_H
+#define EXITCODES_H
+
+#define EXIT_SUCCESS 0
+#define EXIT_FAILURE 1
+#define EXIT_CMDLINE_ERROR 2
+#define EXIT_CONFIG_ERROR 3
+#define EXIT_DEVICE_ERROR 4
+#define EXIT_DRIVER_ERROR 5
+#define EXIT_METER_ERROR 6
+#define EXIT_BUS_DEVICE_ERROR 7
+
+#endif

--- a/src/log.cc
+++ b/src/log.cc
@@ -253,7 +253,7 @@ void debug_int(const char* fmt, ...) {
     if (debug_enabled_) {
         va_list args;
         va_start(args, fmt);
-        output_stuff(LOG_NOTICE, false, fmt, args);
+        output_stuff(LOG_DEBUG, false, fmt, args);
         va_end(args);
     }
 }
@@ -288,10 +288,29 @@ void error(const char* fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    output_stuff(LOG_NOTICE, true, fmt, args);
+    output_stuff(LOG_ERR, true, fmt, args);
+    va_end(args);
+}
+
+[[noreturn]] void critical(int __status, const char* fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    output_stuff(LOG_CRIT, true, fmt, args);
     va_end(args);
     exitHandler(0);
-    exit(1);
+    exit(__status);
+}
+
+
+[[noreturn]] void critical(const char* fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    output_stuff(LOG_CRIT, true, fmt, args);
+    va_end(args);
+    exitHandler(0);
+    exit(0);
 }
 
 void logTelegram(vector<uchar> &original, vector<uchar> &parsed, int header_size, int suffix_size)

--- a/src/log.cc
+++ b/src/log.cc
@@ -310,7 +310,7 @@ void error(const char* fmt, ...)
     output_stuff(LOG_CRIT, true, fmt, args);
     va_end(args);
     exitHandler(0);
-    exit(0);
+    exit(EXIT_FAILURE);
 }
 
 void logTelegram(vector<uchar> &original, vector<uchar> &parsed, int header_size, int suffix_size)

--- a/src/log.h
+++ b/src/log.h
@@ -20,6 +20,7 @@
 
 #include"always.h"
 
+#include<cerrno>
 #include<string>
 #include<vector>
 
@@ -35,6 +36,9 @@ void notice_timestamp(const char* fmt, ...);
 
 void warning(const char* fmt, ...);
 void error(const char* fmt, ...);
+
+[[noreturn]] void critical(const char* fmt, ...);
+[[noreturn]] void critical(int __status, const char* fmt, ...);
 
 #define verbose(...) { if (isVerboseEnabled()) { verbose_int(__VA_ARGS__); } }
 void verbose_int(const char* fmt, ...);

--- a/src/log.h
+++ b/src/log.h
@@ -19,6 +19,7 @@
 #define LOG_H
 
 #include"always.h"
+#include"exitcodes.h"
 
 #include<cerrno>
 #include<string>

--- a/src/lora_iu880b.cc
+++ b/src/lora_iu880b.cc
@@ -269,7 +269,7 @@ bool LoRaIU880B::deviceSetLinkModes(LinkModeSet lms)
     if (!canSetLinkModes(lms))
     {
         string modes = lms.hr();
-        error("(iu880b) setting link mode(s) %s is not supported for iu880b\n", modes.c_str());
+        critical("(iu880b) setting link mode(s) %s is not supported for iu880b\n", modes.c_str());
     }
 
     LOCK_WMBUS_EXECUTING_COMMAND(set_link_modes);

--- a/src/lora_iu880b.cc
+++ b/src/lora_iu880b.cc
@@ -269,7 +269,7 @@ bool LoRaIU880B::deviceSetLinkModes(LinkModeSet lms)
     if (!canSetLinkModes(lms))
     {
         string modes = lms.hr();
-        critical("(iu880b) setting link mode(s) %s is not supported for iu880b\n", modes.c_str());
+        critical(EXIT_BUS_DEVICE_ERROR, "(iu880b) setting link mode(s) %s is not supported for iu880b\n", modes.c_str());
     }
 
     LOCK_WMBUS_EXECUTING_COMMAND(set_link_modes);

--- a/src/main.cc
+++ b/src/main.cc
@@ -98,69 +98,69 @@ int main(int argc, char **argv)
     {
         printf("wmbusmeters: %s\n", VERSION);
         printf(COMMIT "\n");
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
 
     if (config->license)
     {
         printf("%s%s", AUTHORS, LICENSE);
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
 
     if (config->list_shell_envs)
     {
         list_shell_envs(config.get(), config->list_meter);
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
 
     if (config->list_fields)
     {
         list_fields(config.get(), config->list_meter);
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
 
     if (config->print_driver)
     {
         print_driver(config.get(), config->list_meter);
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
 
     if (config->list_meters)
     {
         list_meters(config.get(), true);
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
 
     if (config->list_units)
     {
         list_units();
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
 
     if (config->need_help)
     {
         printf("wmbusmeters version: " VERSION "\n");
         puts(SHORT_MANUAL);
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
 
     if (config->daemon)
     {
         start_daemon(config->pid_file, config->config_root, config->overrides);
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
 
     if (config->useconfig)
     {
         start_using_config_files(config->config_root, false, config->overrides);
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
     else
     {
         // We want the data visible in the log file asap!
         setbuf(stdout, NULL);
         start(config.get());
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
     critical("(main) internal error\n");
 }
@@ -192,7 +192,7 @@ void list_shell_envs(Configuration *config, string meter_driver)
     mi.driver_name = meter_driver;
     if (!lookupDriverInfo(meter_driver, &di))
     {
-        critical("No such driver %s %s\n", meter_driver.c_str(), removedDriverExplanation(meter_driver).c_str());
+        critical(EXIT_DRIVER_ERROR, "No such driver %s %s\n", meter_driver.c_str(), removedDriverExplanation(meter_driver).c_str());
     }
     meter = di.construct(mi);
 
@@ -242,7 +242,7 @@ void list_fields(Configuration *config, string meter_driver)
     mi.driver_name = meter_driver;
     if (!lookupDriverInfo(meter_driver, &di))
     {
-        critical("No such driver %s\n", meter_driver.c_str());
+        critical(EXIT_DRIVER_ERROR, "No such driver %s\n", meter_driver.c_str());
     }
     meter = di.construct(mi);
 
@@ -311,7 +311,7 @@ void print_driver(Configuration *config, string meter_driver)
     mi.driver_name = meter_driver;
     if (!lookupDriverInfo(meter_driver, &di))
     {
-        critical("info='No such driver %s'\n", meter_driver.c_str());
+        critical(EXIT_DRIVER_ERROR, "info='No such driver %s'\n", meter_driver.c_str());
     }
     meter = di.construct(mi);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -162,7 +162,7 @@ int main(int argc, char **argv)
         start(config.get());
         exit(0);
     }
-    error("(main) internal error\n");
+    critical("(main) internal error\n");
 }
 
 shared_ptr<Printer> create_printer(Configuration *config)
@@ -192,7 +192,7 @@ void list_shell_envs(Configuration *config, string meter_driver)
     mi.driver_name = meter_driver;
     if (!lookupDriverInfo(meter_driver, &di))
     {
-        error("No such driver %s %s\n", meter_driver.c_str(), removedDriverExplanation(meter_driver).c_str());
+        critical("No such driver %s %s\n", meter_driver.c_str(), removedDriverExplanation(meter_driver).c_str());
     }
     meter = di.construct(mi);
 
@@ -242,7 +242,7 @@ void list_fields(Configuration *config, string meter_driver)
     mi.driver_name = meter_driver;
     if (!lookupDriverInfo(meter_driver, &di))
     {
-        error("No such driver %s\n", meter_driver.c_str());
+        critical("No such driver %s\n", meter_driver.c_str());
     }
     meter = di.construct(mi);
 
@@ -311,7 +311,7 @@ void print_driver(Configuration *config, string meter_driver)
     mi.driver_name = meter_driver;
     if (!lookupDriverInfo(meter_driver, &di))
     {
-        error("info='No such driver %s'\n", meter_driver.c_str());
+        critical("info='No such driver %s'\n", meter_driver.c_str());
     }
     meter = di.construct(mi);
 
@@ -512,7 +512,7 @@ void setup_log_file(Configuration *config)
             if (config->daemon) {
                 warning("Could not open log file %s will use syslog instead.\n", config->logfile.c_str());
             } else {
-                error("Could not open log file %s\n", config->logfile.c_str());
+                critical("Could not open log file %s\n", config->logfile.c_str());
             }
         }
     }
@@ -555,7 +555,7 @@ bool start(Configuration *config)
     {
         if (config->num_wmbus_devices > 0 && config->all_device_linkmodes_specified.empty())
         {
-            error("Wmbus devices found but no meters supplied. You must supply which link modes to listen to. Eg. auto:c1\n");
+            critical("Wmbus devices found but no meters supplied. You must supply which link modes to listen to. Eg. auto:c1\n");
         }
     }
 
@@ -738,7 +738,7 @@ void start_daemon(string pid_file, string root, ConfigOverrides overrides)
     pid_t pid = fork();
     if (pid < 0)
     {
-        error("Could not fork.\n");
+        critical("Could not fork.\n");
     }
     if (pid > 0)
     {
@@ -758,7 +758,7 @@ void start_daemon(string pid_file, string root, ConfigOverrides overrides)
     }
 
     if ((chdir("/")) < 0) {
-        error("Could not change to root as current working directory.");
+        critical("Could not change to root as current working directory.");
     }
 
     close(STDIN_FILENO);
@@ -766,13 +766,13 @@ void start_daemon(string pid_file, string root, ConfigOverrides overrides)
     close(STDERR_FILENO);
 
     if (open("/dev/null", O_RDONLY) == -1) {
-        error("Failed to reopen stdin while daemonising (errno=%d)",errno);
+        critical("Failed to reopen stdin while daemonising (errno=%d)",errno);
     }
     if (open("/dev/null", O_WRONLY) == -1) {
-        error("Failed to reopen stdout while daemonising (errno=%d)",errno);
+        critical("Failed to reopen stdout while daemonising (errno=%d)",errno);
     }
     if (open("/dev/null", O_RDWR) == -1) {
-        error("Failed to reopen stderr while daemonising (errno=%d)",errno);
+        critical("Failed to reopen stderr while daemonising (errno=%d)",errno);
     }
 
     // In daemon mode, dynamically downloaded drivers will be stored in
@@ -825,12 +825,12 @@ void write_pid(string pid_file, int pid)
 {
     FILE *pidf = fopen(pid_file.c_str(), "w");
     if (!pidf) {
-        error("Could not open pid file \"%s\" for writing!\n", pid_file.c_str());
+        critical("Could not open pid file \"%s\" for writing!\n", pid_file.c_str());
     }
     if (pid > 0) {
         int n = fprintf(pidf, "%d\n", pid);
         if (!n) {
-            error("Could not write pid (%d) to file \"%s\"!\n", pid, pid_file.c_str());
+            critical("Could not write pid (%d) to file \"%s\"!\n", pid, pid_file.c_str());
         }
         notice("(wmbusmeters) started %s\n", pid_file.c_str());
     }

--- a/src/manufacturer_specificities.cc
+++ b/src/manufacturer_specificities.cc
@@ -370,7 +370,7 @@ void qdsExtractWalkByField(Telegram *t, Meter *driver, DVEntry &mfctEntry, int p
 
     FieldInfo *fieldInfo = driver->findFieldInfo(fieldName, quantity);
     if (fieldInfo == nullptr) {
-        critical("(qds) field info not found: %s\n", fieldName.c_str());
+        critical(EXIT_DEVICE_ERROR, "(qds) field info not found: %s\n", fieldName.c_str());
     }
 
     fieldInfo->performExtraction(driver, t, &fieldEntry);

--- a/src/manufacturer_specificities.cc
+++ b/src/manufacturer_specificities.cc
@@ -370,7 +370,7 @@ void qdsExtractWalkByField(Telegram *t, Meter *driver, DVEntry &mfctEntry, int p
 
     FieldInfo *fieldInfo = driver->findFieldInfo(fieldName, quantity);
     if (fieldInfo == nullptr) {
-        error("(qds) field info not found: %s\n", fieldName.c_str());
+        critical("(qds) field info not found: %s\n", fieldName.c_str());
     }
 
     fieldInfo->performExtraction(driver, t, &fieldEntry);

--- a/src/metermanager.cc
+++ b/src/metermanager.cc
@@ -326,7 +326,7 @@ public:
             DriverInfo di;
             if (!lookupDriverInfo(only, &di))
             {
-                critical("No such driver %s\n", only.c_str());
+                critical(EXIT_DRIVER_ERROR, "No such driver %s\n", only.c_str());
             }
             only = di.name().str();
         }

--- a/src/metermanager.cc
+++ b/src/metermanager.cc
@@ -326,7 +326,7 @@ public:
             DriverInfo di;
             if (!lookupDriverInfo(only, &di))
             {
-                error("No such driver %s\n", only.c_str());
+                critical("No such driver %s\n", only.c_str());
             }
             only = di.name().str();
         }
@@ -406,7 +406,7 @@ public:
 
         if (meter_templates_.size() > 0)
         {
-            error("You cannot specify a meter quadruple when analyzing.\n"
+            critical("You cannot specify a meter quadruple when analyzing.\n"
                   "Instead use --analyze=<format>:<driver>:<key>\n"
                   "where <formt> <driver> <key> are all optional.\n"
                   "E.g.        --analyze=terminal:multical21:001122334455667788001122334455667788\n"

--- a/src/meters.cc
+++ b/src/meters.cc
@@ -115,7 +115,6 @@ void addRegisteredDriver(DriverInfo di)
     if (registered_drivers_->count(di.name().str()) != 0)
     {
         critical("Two drivers trying to register the name \"%s\"\n", di.name().str().c_str());
-        exit(1);
     }
 
     (*registered_drivers_)[di.name().str()] = di;

--- a/src/meters.cc
+++ b/src/meters.cc
@@ -114,7 +114,7 @@ void addRegisteredDriver(DriverInfo di)
     verifyDriverLookupCreated();
     if (registered_drivers_->count(di.name().str()) != 0)
     {
-        error("Two drivers trying to register the name \"%s\"\n", di.name().str().c_str());
+        critical("Two drivers trying to register the name \"%s\"\n", di.name().str().c_str());
         exit(1);
     }
 
@@ -185,7 +185,7 @@ bool staticRegisterDriver(function<void(DriverInfo&)> setup)
             bool foo = p->detect(d.mfct, d.version, d.type);
             if (foo)
             {
-                error("Internal error: driver %s tried to register the same auto detect combo as driver %s alread has taken!\n",
+                critical("Internal error: driver %s tried to register the same auto detect combo as driver %s alread has taken!\n",
                       di.name().str().c_str(), p->name().str().c_str());
             }
         }
@@ -219,7 +219,7 @@ string loadDriver(const string &file, const char *content)
     bool ok = DriverDynamic::load(&di, file, content);
     if (!ok)
     {
-        error("Failed to load driver from file: %s\n", file.c_str());
+        critical("Failed to load driver from file: %s\n", file.c_str());
     }
 
     // Check if the driver name has been registered before....
@@ -252,7 +252,7 @@ string loadDriver(const string &file, const char *content)
         else
         {
             // Ok, two xmq drivers in /etc/wmbusmeters.drivers.d that declare the same driver name are NOT ok.
-            error("Conflicting driver names are not permitted. Plese change the driver name in file %s "
+            critical("Conflicting driver names are not permitted. Plese change the driver name in file %s "
                   "to something that is different from %s since the existing driver file %s has already taken the name!\n",
                   file.c_str(), di.name().str().c_str(),
                   existing->getDynamicFileName().c_str());
@@ -320,7 +320,7 @@ string loadDriver(const string &file, const char *content)
                 else
                 {
                     // It is not ok to override an previously dynamically loaded driver though!
-                    error("Newly loaded driver %s (%s) tries to register the same "
+                    critical("Newly loaded driver %s (%s) tries to register the same "
                           "auto detect combo as driver %s (%s) alread has taken! mvt=%s,%02x,%02x\n",
                           di.name().str().c_str(),
                           di.getDynamicFileName().c_str(),
@@ -2427,7 +2427,7 @@ bool is_driver_and_extras(const string& t, DriverName *out_driver_name, string *
         }
         else
         {
-            error("No such driver %s %s\n", t.c_str(), removedDriverExplanation(t).c_str());
+            critical("No such driver %s %s\n", t.c_str(), removedDriverExplanation(t).c_str());
         }
         *out_extras = "";
         return true;
@@ -2447,7 +2447,7 @@ bool is_driver_and_extras(const string& t, DriverName *out_driver_name, string *
     }
     else
     {
-        error("No such driver %s %s\n", type.c_str(), removedDriverExplanation(type).c_str());
+        critical("No such driver %s %s\n", type.c_str(), removedDriverExplanation(type).c_str());
     }
 
     string extras = t.substr(ps+1, pe-ps-1);
@@ -2970,7 +2970,7 @@ bool MeterCommonImplementation::addOptionalLibraryFields(string field_names)
     }
     if (helps.size() > 2)
     {
-        error("Bad library field, only zero or one pipe | symbol is allowed: %s", field_names.c_str());
+        critical("Bad library field, only zero or one pipe | symbol is allowed: %s", field_names.c_str());
     }
 
     if (checkIf(fields,"status-tpl-only"))

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -330,13 +330,13 @@ bool SerialDeviceTTY::open(bool fail_if_not_ok)
     fd_ = openSerialTTY(device_.c_str(), baud_rate_, parity_);
     if (fd_ == -1)
     {
-        if (fail_if_not_ok) error("Could not open %s with %d baud N81\n", device_.c_str(), baud_rate_);
+        if (fail_if_not_ok) critical("Could not open %s with %d baud N81\n", device_.c_str(), baud_rate_);
         verbose("(serialtty) could not open %s with %d baud N81\n", device_.c_str(), baud_rate_);
         return false;
     }
     if (fd_ == -2)
     {
-        if (fail_if_not_ok) error("Device %s is already in use and locked.\n", device_.c_str());
+        if (fail_if_not_ok) critical("Device %s is already in use and locked.\n", device_.c_str());
         verbose("(serialtty) device %s is already in use and locked.\n", device_.c_str());
         return false;
     }
@@ -584,7 +584,7 @@ bool SerialDeviceFile::open(bool fail_if_not_ok)
         {
             if (fail_if_not_ok)
             {
-                error("Could not open file %s for reading.\n", file_.c_str());
+                critical("Could not open file %s for reading.\n", file_.c_str());
             }
             verbose("(serialdevicefile) could not open file %s for reading.\n", file_.c_str());
             return false;
@@ -703,7 +703,7 @@ bool SerialDeviceSocket::open(bool fail_if_not_ok)
     listen_fd_ = socket(AF_UNIX, SOCK_STREAM, 0);
     if (listen_fd_ < 0)
     {
-        if (fail_if_not_ok) error("Could not create unix socket: %s\n", strerror(errno));
+        if (fail_if_not_ok) critical("Could not create unix socket: %s\n", strerror(errno));
         verbose("(serialsocket) could not create unix socket: %s\n", strerror(errno));
         return false;
     }
@@ -713,7 +713,7 @@ bool SerialDeviceSocket::open(bool fail_if_not_ok)
     addr.sun_family = AF_UNIX;
     if (path_.length() >= sizeof(addr.sun_path))
     {
-        if (fail_if_not_ok) error("Socket path too long: %s\n", path_.c_str());
+        if (fail_if_not_ok) critical("Socket path too long: %s\n", path_.c_str());
         verbose("(serialsocket) socket path too long: %s\n", path_.c_str());
         ::close(listen_fd_);
         listen_fd_ = -1;
@@ -725,7 +725,7 @@ bool SerialDeviceSocket::open(bool fail_if_not_ok)
 
     if (::bind(listen_fd_, (struct sockaddr *)&addr, sizeof(addr)) < 0)
     {
-        if (fail_if_not_ok) error("Could not bind unix socket %s: %s\n", path_.c_str(), strerror(errno));
+        if (fail_if_not_ok) critical("Could not bind unix socket %s: %s\n", path_.c_str(), strerror(errno));
         verbose("(serialsocket) could not bind unix socket %s: %s\n", path_.c_str(), strerror(errno));
         ::close(listen_fd_);
         listen_fd_ = -1;
@@ -734,7 +734,7 @@ bool SerialDeviceSocket::open(bool fail_if_not_ok)
 
     if (listen(listen_fd_, 1) < 0)
     {
-        if (fail_if_not_ok) error("Could not listen on unix socket %s: %s\n", path_.c_str(), strerror(errno));
+        if (fail_if_not_ok) critical("Could not listen on unix socket %s: %s\n", path_.c_str(), strerror(errno));
         verbose("(serialsocket) could not listen on unix socket %s: %s\n", path_.c_str(), strerror(errno));
         ::close(listen_fd_);
         listen_fd_ = -1;
@@ -933,7 +933,7 @@ void SerialCommunicationManagerImp::listenTo(SerialDevice *sd, function<void()> 
     SerialDeviceImp *si = dynamic_cast<SerialDeviceImp*>(sd);
     if (!si)
     {
-        error("Internal error: Invalid serial device passed to listenTo.\n");
+        critical("Internal error: Invalid serial device passed to listenTo.\n");
     }
     si->on_data_ = cb;
 }
@@ -944,7 +944,7 @@ void SerialCommunicationManagerImp::onDisappear(SerialDevice *sd, function<void(
     SerialDeviceImp *si = dynamic_cast<SerialDeviceImp*>(sd);
     if (!si)
     {
-        error("Internal error: Invalid serial device passed to onDisappear.\n");
+        critical("Internal error: Invalid serial device passed to onDisappear.\n");
     }
     si->on_disappear_ = cb;
 }

--- a/src/shell.cc
+++ b/src/shell.cc
@@ -98,7 +98,7 @@ void invokeShell(string program, vector<string> args, vector<string> envs)
         _exit(127);
     } else {
         if (pid == -1) {
-            error("(shell) could not fork!\n");
+            critical("(shell) could not fork!\n");
         }
         debug("(shell) waiting for child %d to complete.\n", pid);
         // Wait for the child to finish!
@@ -137,7 +137,7 @@ bool invokeBackgroundShell(string program, vector<string> args, vector<string> e
     vector<const char*> env = prepareEnv(envs);
 
     if (pipe(link) == -1) {
-        error("(bgshell) could not create pipe!\n");
+        critical("(bgshell) could not create pipe!\n");
     }
 
     *pid = fork();
@@ -275,7 +275,7 @@ int invokeShellCaptureOutput(string program, vector<string> args, vector<string>
     vector<const char*> env = prepareEnv(envs);
 
     if (pipe(link) == -1) {
-        error("(shell) could not create pipe!\n");
+        critical("(shell) could not create pipe!\n");
     }
 
     pid = fork();

--- a/src/threads.cc
+++ b/src/threads.cc
@@ -168,7 +168,7 @@ bool Semaphore::wait()
         if (!rc) break;
         if (rc == EINTR) continue;
         if (rc == ETIMEDOUT) break;
-        error("(thread) pthread cond timedwait ERROR %d\n", rc);
+        critical("(thread) pthread cond timedwait ERROR %d\n", rc);
     }
 
     pthread_mutex_unlock(&mutex_);
@@ -186,7 +186,7 @@ void Semaphore::notify()
     int rc = pthread_cond_signal(&condition_);
     if (rc)
     {
-        error("(thread) pthread cond signal ERROR\n");
+        critical("(thread) pthread cond signal ERROR\n");
     }
 }
 

--- a/src/units.cc
+++ b/src/units.cc
@@ -473,7 +473,7 @@ void assertQuantity(Unit u, Quantity q)
 {
     if (!isQuantity(u, q))
     {
-        error("Internal error! Unit is not of this quantity.\n");
+        critical("Internal error! Unit is not of this quantity.\n");
     }
 }
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -454,14 +454,14 @@ bool checkCharacterDeviceExists(const char *tty, bool fail_if_not)
     int rc = stat(tty, &info);
     if (rc != 0) {
         if (fail_if_not) {
-            critical("Device \"%s\" does not exist.\n", tty);
+            critical(EXIT_DEVICE_ERROR, "Device \"%s\" does not exist.\n", tty);
         } else {
             return false;
         }
     }
     if (!S_ISCHR(info.st_mode)) {
         if (fail_if_not) {
-            critical("Device %s is not a character device.\n", tty);
+            critical(EXIT_DEVICE_ERROR, "Device %s is not a character device.\n", tty);
         } else {
             return false;
         }

--- a/src/util.cc
+++ b/src/util.cc
@@ -454,14 +454,14 @@ bool checkCharacterDeviceExists(const char *tty, bool fail_if_not)
     int rc = stat(tty, &info);
     if (rc != 0) {
         if (fail_if_not) {
-            error("Device \"%s\" does not exist.\n", tty);
+            critical("Device \"%s\" does not exist.\n", tty);
         } else {
             return false;
         }
     }
     if (!S_ISCHR(info.st_mode)) {
         if (fail_if_not) {
-            error("Device %s is not a character device.\n", tty);
+            critical("Device %s is not a character device.\n", tty);
         } else {
             return false;
         }
@@ -701,7 +701,7 @@ int loadFile(const string& file, vector<string> *lines)
             if (errno == EINTR) {
                 continue;
             }
-            error("Could not read file %s errno=%d\n", file.c_str(), errno);
+            critical("Could not read file %s errno=%d\n", file.c_str(), errno);
             close(fd);
             return -1;
         }
@@ -717,7 +717,7 @@ int loadFile(const string& file, vector<string> *lines)
     for (;;) {
         string line = eatTo(buf, i, '\n', 32768, &eof, &err);
         if (err) {
-            error("Error parsing simulation file.\n");
+            critical("Error parsing simulation file.\n");
         }
         if (line.length() > 0) {
             lines->push_back(line);
@@ -982,7 +982,7 @@ AccessCheck checkIfExistsAndHasAccess(const string& device)
     // What are the groups I am member of?
     int rc = getgrouplist(p->pw_name, p->pw_gid, my_groups, &ngroups);
     if (rc < 0) {
-        error("(wmbusmeters) cannot handle users with more than 256 groups\n");
+        critical("(wmbusmeters) cannot handle users with more than 256 groups\n");
     }
 
     // What is the group of the tty?

--- a/src/wmbus.cc
+++ b/src/wmbus.cc
@@ -124,7 +124,7 @@ LinkModeSet parseLinkModes(string m)
         LinkMode lm = toLinkMode(tok);
         if (lm == LinkMode::UNKNOWN)
         {
-            error("(wmbus) not a valid link mode: %s\n", tok);
+            critical("(wmbus) not a valid link mode: %s\n", tok);
         }
         lms.addLinkMode(lm);
         tok = strtok_r(NULL, ",", &saveptr);
@@ -4558,7 +4558,7 @@ bool BusDeviceCommonImplementation::waitForResponse(int id)
 
     if (waiting_for_response_id_ != 0)
     {
-        error("(wmbus) bad internal state tried waitForResponse(%d) but already waiting for %d! Exiting!\n", id, waiting_for_response_id_);
+        critical("(wmbus) bad internal state tried waitForResponse(%d) but already waiting for %d! Exiting!\n", id, waiting_for_response_id_);
     }
 
     waiting_for_response_id_ = id;
@@ -5783,7 +5783,7 @@ Detected detectBusDeviceWithFileOrHex(SpecifiedDevice &specified_device,
     LinkModeSet desired_linkmodes = lms;
     if (specified_device.type == BusDeviceType::DEVICE_UNKNOWN)
     {
-        error("You have to specify the expected device type for the tty %s\n",
+        critical("You have to specify the expected device type for the tty %s\n",
               specified_device.file.c_str());
     }
 

--- a/src/wmbus_amb8465.cc
+++ b/src/wmbus_amb8465.cc
@@ -589,7 +589,7 @@ bool WMBusAmber::deviceSetLinkModes(LinkModeSet lms)
     if (!canSetLinkModes(lms))
     {
         string modes = lms.hr();
-        error("(amb8465) setting link mode(s) %s is not supported for amb8465 \n", modes.c_str());
+        critical("(amb8465) setting link mode(s) %s is not supported for amb8465 \n", modes.c_str());
     }
 
     {
@@ -889,7 +889,7 @@ bool WMBusAmber::sendTelegram(LinkMode lm, TelegramFormat format, vector<uchar> 
 
     if (link_mode == 0xff)
     {
-        error("(amb8465) setting link mode %s for sending is not supported for amb8465 \n", toString(lm));
+        critical("(amb8465) setting link mode %s for sending is not supported for amb8465 \n", toString(lm));
     }
 
     {

--- a/src/wmbus_amb8465.cc
+++ b/src/wmbus_amb8465.cc
@@ -589,7 +589,7 @@ bool WMBusAmber::deviceSetLinkModes(LinkModeSet lms)
     if (!canSetLinkModes(lms))
     {
         string modes = lms.hr();
-        critical("(amb8465) setting link mode(s) %s is not supported for amb8465 \n", modes.c_str());
+        critical(EXIT_BUS_DEVICE_ERROR, "(amb8465) setting link mode(s) %s is not supported for amb8465 \n", modes.c_str());
     }
 
     {
@@ -889,7 +889,7 @@ bool WMBusAmber::sendTelegram(LinkMode lm, TelegramFormat format, vector<uchar> 
 
     if (link_mode == 0xff)
     {
-        critical("(amb8465) setting link mode %s for sending is not supported for amb8465 \n", toString(lm));
+        critical(EXIT_BUS_DEVICE_ERROR, "(amb8465) setting link mode %s for sending is not supported for amb8465 \n", toString(lm));
     }
 
     {

--- a/src/wmbus_cul.cc
+++ b/src/wmbus_cul.cc
@@ -157,7 +157,7 @@ bool WMBusCUL::deviceSetLinkModes(LinkModeSet lms)
     if (!canSetLinkModes(lms))
     {
         string modes = lms.hr();
-        critical("(cul) setting link mode(s) %s is not supported\n", modes.c_str());
+        critical(EXIT_BUS_DEVICE_ERROR, "(cul) setting link mode(s) %s is not supported\n", modes.c_str());
     }
 
     {
@@ -203,7 +203,7 @@ bool WMBusCUL::deviceSetLinkModes(LinkModeSet lms)
     if (!ok)
     {
         string modes = lms.hr();
-        critical("(cul) setting link mode(s) %s is not supported for this cul device!\n", modes.c_str());
+        critical(EXIT_BUS_DEVICE_ERROR, "(cul) setting link mode(s) %s is not supported for this cul device!\n", modes.c_str());
     }
 
     // X01 - start the receiver in normal mode

--- a/src/wmbus_cul.cc
+++ b/src/wmbus_cul.cc
@@ -157,7 +157,7 @@ bool WMBusCUL::deviceSetLinkModes(LinkModeSet lms)
     if (!canSetLinkModes(lms))
     {
         string modes = lms.hr();
-        error("(cul) setting link mode(s) %s is not supported\n", modes.c_str());
+        critical("(cul) setting link mode(s) %s is not supported\n", modes.c_str());
     }
 
     {
@@ -203,7 +203,7 @@ bool WMBusCUL::deviceSetLinkModes(LinkModeSet lms)
     if (!ok)
     {
         string modes = lms.hr();
-        error("(cul) setting link mode(s) %s is not supported for this cul device!\n", modes.c_str());
+        critical("(cul) setting link mode(s) %s is not supported for this cul device!\n", modes.c_str());
     }
 
     // X01 - start the receiver in normal mode

--- a/src/wmbus_im871a.cc
+++ b/src/wmbus_im871a.cc
@@ -692,7 +692,7 @@ bool WMBusIM871aIM170A::deviceSetLinkModes(LinkModeSet lms)
     if (!canSetLinkModes(lms))
     {
         string modes = lms.hr();
-        critical("(im871a) setting link mode(s) %s is not supported for im871a\n", modes.c_str());
+        critical(EXIT_BUS_DEVICE_ERROR, "(im871a) setting link mode(s) %s is not supported for im871a\n", modes.c_str());
     }
 
     LOCK_WMBUS_EXECUTING_COMMAND(set_link_modes);

--- a/src/wmbus_im871a.cc
+++ b/src/wmbus_im871a.cc
@@ -692,7 +692,7 @@ bool WMBusIM871aIM170A::deviceSetLinkModes(LinkModeSet lms)
     if (!canSetLinkModes(lms))
     {
         string modes = lms.hr();
-        error("(im871a) setting link mode(s) %s is not supported for im871a\n", modes.c_str());
+        critical("(im871a) setting link mode(s) %s is not supported for im871a\n", modes.c_str());
     }
 
     LOCK_WMBUS_EXECUTING_COMMAND(set_link_modes);

--- a/src/wmbus_iu891a.cc
+++ b/src/wmbus_iu891a.cc
@@ -476,7 +476,7 @@ bool WMBusIU891A::deviceSetLinkModes(LinkModeSet lms)
     if (!canSetLinkModes(lms))
     {
         string modes = lms.hr();
-        critical("(iu871a) setting link mode(s) %s is not supported for iu891a\n", modes.c_str());
+        critical(EXIT_BUS_DEVICE_ERROR, "(iu871a) setting link mode(s) %s is not supported for iu891a\n", modes.c_str());
     }
 
     LOCK_WMBUS_EXECUTING_COMMAND(set_link_modes);

--- a/src/wmbus_iu891a.cc
+++ b/src/wmbus_iu891a.cc
@@ -476,7 +476,7 @@ bool WMBusIU891A::deviceSetLinkModes(LinkModeSet lms)
     if (!canSetLinkModes(lms))
     {
         string modes = lms.hr();
-        error("(iu871a) setting link mode(s) %s is not supported for iu891a\n", modes.c_str());
+        critical("(iu871a) setting link mode(s) %s is not supported for iu891a\n", modes.c_str());
     }
 
     LOCK_WMBUS_EXECUTING_COMMAND(set_link_modes);

--- a/src/wmbus_rc1180.cc
+++ b/src/wmbus_rc1180.cc
@@ -326,7 +326,7 @@ bool WMBusRC1180::deviceSetLinkModes(LinkModeSet lms)
     if (!canSetLinkModes(lms))
     {
         string modes = lms.hr();
-        critical("(rc1180) setting link mode(s) %s is not supported\n", modes.c_str());
+        critical(EXIT_BUS_DEVICE_ERROR, "(rc1180) setting link mode(s) %s is not supported\n", modes.c_str());
     }
 
     // Do not actually try to change the link mode, we assume it is T1.

--- a/src/wmbus_rc1180.cc
+++ b/src/wmbus_rc1180.cc
@@ -326,7 +326,7 @@ bool WMBusRC1180::deviceSetLinkModes(LinkModeSet lms)
     if (!canSetLinkModes(lms))
     {
         string modes = lms.hr();
-        error("(rc1180) setting link mode(s) %s is not supported\n", modes.c_str());
+        critical("(rc1180) setting link mode(s) %s is not supported\n", modes.c_str());
     }
 
     // Do not actually try to change the link mode, we assume it is T1.

--- a/src/wmbus_rtl433.cc
+++ b/src/wmbus_rtl433.cc
@@ -92,7 +92,7 @@ shared_ptr<BusDevice> openRTL433(Detected detected, string bin_dir, bool daemon,
     bool ok = parseExtras(detected.specified_device.extras, &extras);
     if (!ok)
     {
-        error("(rtl433) invalid extra parameters to rtl433 (%s)\n", detected.specified_device.extras.c_str());
+        critical("(rtl433) invalid extra parameters to rtl433 (%s)\n", detected.specified_device.extras.c_str());
     }
     string ppm = "";
     if (extras.size() > 0)
@@ -123,7 +123,7 @@ shared_ptr<BusDevice> openRTL433(Detected detected, string bin_dir, bool daemon,
         {
             if (daemon)
             {
-                error("(rtl433) error: when starting as daemon, wmbusmeters looked for %s/rtl_433 and %s/rtl_sdr, but found neither!\n",
+                critical("(rtl433) error: when starting as daemon, wmbusmeters looked for %s/rtl_433 and %s/rtl_sdr, but found neither!\n",
                       bin_dir.c_str(), "/usr/bin");
             }
             else

--- a/src/wmbus_rtl433.cc
+++ b/src/wmbus_rtl433.cc
@@ -92,7 +92,7 @@ shared_ptr<BusDevice> openRTL433(Detected detected, string bin_dir, bool daemon,
     bool ok = parseExtras(detected.specified_device.extras, &extras);
     if (!ok)
     {
-        critical("(rtl433) invalid extra parameters to rtl433 (%s)\n", detected.specified_device.extras.c_str());
+        critical(EXIT_BUS_DEVICE_ERROR, "(rtl433) invalid extra parameters to rtl433 (%s)\n", detected.specified_device.extras.c_str());
     }
     string ppm = "";
     if (extras.size() > 0)
@@ -123,7 +123,7 @@ shared_ptr<BusDevice> openRTL433(Detected detected, string bin_dir, bool daemon,
         {
             if (daemon)
             {
-                critical("(rtl433) error: when starting as daemon, wmbusmeters looked for %s/rtl_433 and %s/rtl_sdr, but found neither!\n",
+                critical(EXIT_BUS_DEVICE_ERROR, "(rtl433) error: when starting as daemon, wmbusmeters looked for %s/rtl_433 and %s/rtl_sdr, but found neither!\n",
                       bin_dir.c_str(), "/usr/bin");
             }
             else

--- a/src/wmbus_rtlwmbus.cc
+++ b/src/wmbus_rtlwmbus.cc
@@ -103,7 +103,7 @@ shared_ptr<BusDevice> openRTLWMBUS(Detected detected,
     bool ok = parseExtras(detected.specified_device.extras, &extras);
     if (!ok)
     {
-        critical("(rtlwmbus) invalid extra parameters to rtlwmbus (%s)\n", detected.specified_device.extras.c_str());
+        critical(EXIT_BUS_DEVICE_ERROR, "(rtlwmbus) invalid extra parameters to rtlwmbus (%s)\n", detected.specified_device.extras.c_str());
     }
     string ppm = "";
     if (extras.size() > 0)
@@ -138,7 +138,7 @@ shared_ptr<BusDevice> openRTLWMBUS(Detected detected,
         {
             if (daemon)
             {
-                critical("(rtlwmbus) error: when starting as daemon, wmbusmeters looked for %s/rtl_sdr and %s/rtl_sdr, but found neither!\n",
+                critical(EXIT_BUS_DEVICE_ERROR, "(rtlwmbus) error: when starting as daemon, wmbusmeters looked for %s/rtl_sdr and %s/rtl_sdr, but found neither!\n",
                       bin_dir.c_str(), "/usr/bin");
             }
             else
@@ -152,7 +152,7 @@ shared_ptr<BusDevice> openRTLWMBUS(Detected detected,
         {
             if (daemon)
             {
-                critical("(rtlwmbus) error: when starting as daemon, wmbusmeters looked for %s/rtl_wmbus and %s/rtl_wmbus, but found neither!\n",
+                critical(EXIT_BUS_DEVICE_ERROR, "(rtlwmbus) error: when starting as daemon, wmbusmeters looked for %s/rtl_wmbus and %s/rtl_wmbus, but found neither!\n",
                       bin_dir.c_str(), "/usr/bin");
             }
             else

--- a/src/wmbus_rtlwmbus.cc
+++ b/src/wmbus_rtlwmbus.cc
@@ -103,7 +103,7 @@ shared_ptr<BusDevice> openRTLWMBUS(Detected detected,
     bool ok = parseExtras(detected.specified_device.extras, &extras);
     if (!ok)
     {
-        error("(rtlwmbus) invalid extra parameters to rtlwmbus (%s)\n", detected.specified_device.extras.c_str());
+        critical("(rtlwmbus) invalid extra parameters to rtlwmbus (%s)\n", detected.specified_device.extras.c_str());
     }
     string ppm = "";
     if (extras.size() > 0)
@@ -138,7 +138,7 @@ shared_ptr<BusDevice> openRTLWMBUS(Detected detected,
         {
             if (daemon)
             {
-                error("(rtlwmbus) error: when starting as daemon, wmbusmeters looked for %s/rtl_sdr and %s/rtl_sdr, but found neither!\n",
+                critical("(rtlwmbus) error: when starting as daemon, wmbusmeters looked for %s/rtl_sdr and %s/rtl_sdr, but found neither!\n",
                       bin_dir.c_str(), "/usr/bin");
             }
             else
@@ -152,7 +152,7 @@ shared_ptr<BusDevice> openRTLWMBUS(Detected detected,
         {
             if (daemon)
             {
-                error("(rtlwmbus) error: when starting as daemon, wmbusmeters looked for %s/rtl_wmbus and %s/rtl_wmbus, but found neither!\n",
+                critical("(rtlwmbus) error: when starting as daemon, wmbusmeters looked for %s/rtl_wmbus and %s/rtl_wmbus, but found neither!\n",
                       bin_dir.c_str(), "/usr/bin");
             }
             else

--- a/src/wmbus_simulator.cc
+++ b/src/wmbus_simulator.cc
@@ -175,7 +175,7 @@ void WMBusSimulator::simulate()
         bool ok = hex2bin(hex.c_str(), &payload);
         if (!ok)
         {
-            critical("Not a valid string of hex bytes! \"%s\"\n", l.c_str());
+            critical(EXIT_BUS_DEVICE_ERROR, "Not a valid string of hex bytes! \"%s\"\n", l.c_str());
         }
 
         size_t frame_length;

--- a/src/wmbus_simulator.cc
+++ b/src/wmbus_simulator.cc
@@ -175,7 +175,7 @@ void WMBusSimulator::simulate()
         bool ok = hex2bin(hex.c_str(), &payload);
         if (!ok)
         {
-            error("Not a valid string of hex bytes! \"%s\"\n", l.c_str());
+            critical("Not a valid string of hex bytes! \"%s\"\n", l.c_str());
         }
 
         size_t frame_length;

--- a/src/wmbus_socket.cc
+++ b/src/wmbus_socket.cc
@@ -112,7 +112,7 @@ shared_ptr<BusDevice> openSocket(Detected detected,
 
     if (socket_path.empty())
     {
-        critical("(socket) no socket path specified. Use SOCKET(/path/to/socket)\n");
+        critical(EXIT_BUS_DEVICE_ERROR, "(socket) no socket path specified. Use SOCKET(/path/to/socket)\n");
     }
 
     auto serial = manager->createSerialDeviceSocket(socket_path, "socket");

--- a/src/wmbus_socket.cc
+++ b/src/wmbus_socket.cc
@@ -112,7 +112,7 @@ shared_ptr<BusDevice> openSocket(Detected detected,
 
     if (socket_path.empty())
     {
-        error("(socket) no socket path specified. Use SOCKET(/path/to/socket)\n");
+        critical("(socket) no socket path specified. Use SOCKET(/path/to/socket)\n");
     }
 
     auto serial = manager->createSerialDeviceSocket(socket_path, "socket");

--- a/tests/test_hex_cmdline.sh
+++ b/tests/test_hex_cmdline.sh
@@ -78,7 +78,7 @@ EOF
 
 $PROG 2A442D2C998734761B168D2091D37CAC21E1D68CDAFFCD3DC452BD802913FF7B1706CA9E355D6C2701CC2 2> $TEST/test_output.txt 1>&2
 
-if [ "$?" = "1" ]
+if [ "$?" != "1" ]
 then
     diff $TEST/test_expected.txt $TEST/test_output.txt
     if [ "$?" = "0" ]


### PR DESCRIPTION
In my opinion, `warning()` and `error()` are not "correctly" implemented. 

In my opinion we should use following systematic approach:
- `warning()` -> something irregular happened, but does not affect the processing, e.g. a settingg was set wrong and we do a fallback to the default value
- `error()` -> something happened, which affects the processing of the current task, but the overall processing is ensured, e.g. invalid telegram got received and we drop it
- `critical()` -> something happened, which not only affects the processing of the current task, but is so disruptive, that running wmbusmeters in sane and deterministic way is not possible

As first step i implemented critical. And changed the occurence of most error calls to critical. 

Next step would be to make some `warnings()` calls to be `error()` calls

btw. no use of LLM.